### PR TITLE
Feature/82 replace moq with nsubstitute

### DIFF
--- a/src/Vts.Test/Common/Logging/AbstractLoggerFactoryTests.cs
+++ b/src/Vts.Test/Common/Logging/AbstractLoggerFactoryTests.cs
@@ -1,4 +1,4 @@
-﻿using Moq;
+﻿using NSubstitute;
 using NUnit.Framework;
 using System;
 using Vts.Common.Logging;
@@ -9,46 +9,38 @@ namespace Vts.Test.Common.Logging
     [TestFixture]
     public class AbstractLoggerFactoryTests
     {
+        private AbstractLoggerFactory _loggerMock;
+
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            _loggerMock = Substitute.ForPartsOf<AbstractLoggerFactory>();
+        }
+
         [Test]
         public void Test_create_logger_type_only()
         {
-            var loggerMock = new Mock<AbstractLoggerFactory>()
-            {
-                CallBase = true
-            };
-            loggerMock.Setup(x => x.Create(It.IsAny<String>())).Returns(new NLogLogger());
-            Assert.IsInstanceOf<NLogLogger>(loggerMock.Object.Create(typeof(AbstractLoggerFactoryTests)));
+            _loggerMock.Create(Arg.Any<string>()).Returns(new NLogLogger());
+            Assert.IsInstanceOf<NLogLogger>(_loggerMock.Create(typeof(AbstractLoggerFactoryTests)));
         }
 
         [Test]
         public void Test_create_logger_type_null_throws_argument_null_exception()
         {
-            var loggerMock = new Mock<AbstractLoggerFactory>()
-            {
-                CallBase = true
-            };
-            Assert.Throws<ArgumentNullException>(() => loggerMock.Object.Create((Type)null));
+            Assert.Throws<ArgumentNullException>(() => _loggerMock.Create((Type)null));
         }
 
         [Test]
         public void Test_create_logger_type_null_level_throws_argument_null_exception()
         {
-            var loggerMock = new Mock<AbstractLoggerFactory>()
-            {
-                CallBase = true
-            };
-            Assert.Throws<ArgumentNullException>(() => loggerMock.Object.Create((Type)null, LoggerLevel.Info));
+            Assert.Throws<ArgumentNullException>(() => _loggerMock.Create((Type)null, LoggerLevel.Info));
         }
 
         [Test]
         public void Test_create_logger_type_and_level()
         {
-            var loggerMock = new Mock<AbstractLoggerFactory>()
-            {
-                CallBase = true
-            };
-            loggerMock.Setup(x => x.Create(It.IsAny<String>(), It.IsAny<LoggerLevel>())).Returns(new NLogLogger());
-            Assert.IsInstanceOf<NLogLogger>(loggerMock.Object.Create(typeof(AbstractLoggerFactoryTests), LoggerLevel.Error));
+            _loggerMock.Create(Arg.Any<string>(), Arg.Any<LoggerLevel>()).Returns(new NLogLogger());
+            Assert.IsInstanceOf<NLogLogger>(_loggerMock.Create(typeof(AbstractLoggerFactoryTests), LoggerLevel.Error));
         }
     }
 }

--- a/src/Vts.Test/Common/Logging/NLogLoggerTests.cs
+++ b/src/Vts.Test/Common/Logging/NLogLoggerTests.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using Moq;
-using NLog;
+﻿using NLog;
+using NSubstitute;
 using NUnit.Framework;
-using NUnit.Framework.Internal;
+using System;
 using Vts.Common.Logging.NLogIntegration;
 using Logger = NLog.Logger;
 
@@ -13,14 +12,14 @@ namespace Vts.Test.Common.Logging
     {
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
         private NLogLogger _nLogLogger;
-        private Mock<IFormatProvider> _formatProviderMock;
+        private IFormatProvider _formatProviderMock;
 
         [OneTimeSetUp]
         public void One_time_setup()
         {
             _nLogLogger = new NLogLogger(Logger, new NLogFactory());
-            _formatProviderMock = new Mock<IFormatProvider>();
-            _formatProviderMock.Setup(x => x.GetFormat(It.IsAny<Type>())).Returns((ICustomFormatter)null);
+            _formatProviderMock = Substitute.For<IFormatProvider>();
+            _formatProviderMock.GetFormat(Arg.Any<Type>()).Returns((ICustomFormatter)null);
         }
 
         [Test]
@@ -86,10 +85,10 @@ namespace Vts.Test.Common.Logging
             Assert.DoesNotThrow(() => _nLogLogger.Debug("message"));
             Assert.DoesNotThrow(() => _nLogLogger.Debug("message", new NullReferenceException("Object not set to an instance of an object")));
             Assert.DoesNotThrow(() => _nLogLogger.Debug(() => "message"));
-            Assert.DoesNotThrow(() => _nLogLogger.DebugFormat("format", new object[] {}));
-            Assert.DoesNotThrow(() => _nLogLogger.DebugFormat(new NullReferenceException("Object not set to an instance of an object"), "format", new object[] {}));
-            Assert.DoesNotThrow(() => _nLogLogger.DebugFormat(_formatProviderMock.Object, "format", new object[] { }));
-            Assert.DoesNotThrow(() => _nLogLogger.DebugFormat(new NullReferenceException("Object not set to an instance of an object"), _formatProviderMock.Object, "format", new object[] { }));
+            Assert.DoesNotThrow(() => _nLogLogger.DebugFormat("format"));
+            Assert.DoesNotThrow(() => _nLogLogger.DebugFormat(new NullReferenceException("Object not set to an instance of an object"), "format"));
+            Assert.DoesNotThrow(() => _nLogLogger.DebugFormat(_formatProviderMock, "format"));
+            Assert.DoesNotThrow(() => _nLogLogger.DebugFormat(new NullReferenceException("Object not set to an instance of an object"), _formatProviderMock, "format"));
         }
 
         [Test]
@@ -98,10 +97,10 @@ namespace Vts.Test.Common.Logging
             Assert.DoesNotThrow(() => _nLogLogger.Info("message"));
             Assert.DoesNotThrow(() => _nLogLogger.Info("message", new NullReferenceException("Object not set to an instance of an object")));
             Assert.DoesNotThrow(() => _nLogLogger.Info(() => "message"));
-            Assert.DoesNotThrow(() => _nLogLogger.InfoFormat("format", new object[] { }));
-            Assert.DoesNotThrow(() => _nLogLogger.InfoFormat(new NullReferenceException("Object not set to an instance of an object"), "format", new object[] { }));
-            Assert.DoesNotThrow(() => _nLogLogger.InfoFormat(_formatProviderMock.Object, "format", new object[] { }));
-            Assert.DoesNotThrow(() => _nLogLogger.InfoFormat(new NullReferenceException("Object not set to an instance of an object"), _formatProviderMock.Object, "format", new object[] { }));
+            Assert.DoesNotThrow(() => _nLogLogger.InfoFormat("format"));
+            Assert.DoesNotThrow(() => _nLogLogger.InfoFormat(new NullReferenceException("Object not set to an instance of an object"), "format"));
+            Assert.DoesNotThrow(() => _nLogLogger.InfoFormat(_formatProviderMock, "format"));
+            Assert.DoesNotThrow(() => _nLogLogger.InfoFormat(new NullReferenceException("Object not set to an instance of an object"), _formatProviderMock, "format"));
         }
 
         [Test]
@@ -110,10 +109,10 @@ namespace Vts.Test.Common.Logging
             Assert.DoesNotThrow(() => _nLogLogger.Warn("message"));
             Assert.DoesNotThrow(() => _nLogLogger.Warn("message", new NullReferenceException("Object not set to an instance of an object")));
             Assert.DoesNotThrow(() => _nLogLogger.Warn(() => "message"));
-            Assert.DoesNotThrow(() => _nLogLogger.WarnFormat("format", new object[] { }));
-            Assert.DoesNotThrow(() => _nLogLogger.WarnFormat(new NullReferenceException("Object not set to an instance of an object"), "format", new object[] { }));
-            Assert.DoesNotThrow(() => _nLogLogger.WarnFormat(_formatProviderMock.Object, "format", new object[] { }));
-            Assert.DoesNotThrow(() => _nLogLogger.WarnFormat(new NullReferenceException("Object not set to an instance of an object"), _formatProviderMock.Object, "format", new object[] { }));
+            Assert.DoesNotThrow(() => _nLogLogger.WarnFormat("format"));
+            Assert.DoesNotThrow(() => _nLogLogger.WarnFormat(new NullReferenceException("Object not set to an instance of an object"), "format"));
+            Assert.DoesNotThrow(() => _nLogLogger.WarnFormat(_formatProviderMock, "format"));
+            Assert.DoesNotThrow(() => _nLogLogger.WarnFormat(new NullReferenceException("Object not set to an instance of an object"), _formatProviderMock, "format"));
         }
 
         [Test]
@@ -122,10 +121,10 @@ namespace Vts.Test.Common.Logging
             Assert.DoesNotThrow(() => _nLogLogger.Error("message"));
             Assert.DoesNotThrow(() => _nLogLogger.Error("message", new NullReferenceException("Object not set to an instance of an object")));
             Assert.DoesNotThrow(() => _nLogLogger.Error(() => "message"));
-            Assert.DoesNotThrow(() => _nLogLogger.ErrorFormat("format", new object[] { }));
-            Assert.DoesNotThrow(() => _nLogLogger.ErrorFormat(new NullReferenceException("Object not set to an instance of an object"), "format", new object[] { }));
-            Assert.DoesNotThrow(() => _nLogLogger.ErrorFormat(_formatProviderMock.Object, "format", new object[] { }));
-            Assert.DoesNotThrow(() => _nLogLogger.ErrorFormat(new NullReferenceException("Object not set to an instance of an object"), _formatProviderMock.Object, "format", new object[] { }));
+            Assert.DoesNotThrow(() => _nLogLogger.ErrorFormat("format"));
+            Assert.DoesNotThrow(() => _nLogLogger.ErrorFormat(new NullReferenceException("Object not set to an instance of an object"), "format"));
+            Assert.DoesNotThrow(() => _nLogLogger.ErrorFormat(_formatProviderMock, "format"));
+            Assert.DoesNotThrow(() => _nLogLogger.ErrorFormat(new NullReferenceException("Object not set to an instance of an object"), _formatProviderMock, "format"));
         }
 
         [Test]
@@ -134,10 +133,10 @@ namespace Vts.Test.Common.Logging
             Assert.DoesNotThrow(() => _nLogLogger.Fatal("message"));
             Assert.DoesNotThrow(() => _nLogLogger.Fatal("message", new NullReferenceException("Object not set to an instance of an object")));
             Assert.DoesNotThrow(() => _nLogLogger.Fatal(() => "message"));
-            Assert.DoesNotThrow(() => _nLogLogger.FatalFormat("format", new object[] { }));
-            Assert.DoesNotThrow(() => _nLogLogger.FatalFormat(new NullReferenceException("Object not set to an instance of an object"), "format", new object[] { }));
-            Assert.DoesNotThrow(() => _nLogLogger.FatalFormat(_formatProviderMock.Object, "format", new object[] { }));
-            Assert.DoesNotThrow(() => _nLogLogger.FatalFormat(new NullReferenceException("Object not set to an instance of an object"), _formatProviderMock.Object, "format", new object[] { }));
+            Assert.DoesNotThrow(() => _nLogLogger.FatalFormat("format"));
+            Assert.DoesNotThrow(() => _nLogLogger.FatalFormat(new NullReferenceException("Object not set to an instance of an object"), "format"));
+            Assert.DoesNotThrow(() => _nLogLogger.FatalFormat(_formatProviderMock, "format"));
+            Assert.DoesNotThrow(() => _nLogLogger.FatalFormat(new NullReferenceException("Object not set to an instance of an object"), _formatProviderMock, "format"));
         }
     }
 }

--- a/src/Vts.Test/Extensions/EnumerableExtensionsTests.cs
+++ b/src/Vts.Test/Extensions/EnumerableExtensionsTests.cs
@@ -1,8 +1,8 @@
-﻿using System;
+﻿using NSubstitute;
+using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using Moq;
-using NUnit.Framework;
 using Vts.Extensions;
 using Vts.Modeling.ForwardSolvers;
 
@@ -11,23 +11,17 @@ namespace Vts.Test.Extensions
     [TestFixture]
     public class EnumerableExtensionsTests
     {
-        private Mock<ForwardSolverBase> _forwardSolverBaseMock;
-        private Mock<ForwardSolverBase> _forwardSolverBaseMockWithSetup;
+        private ForwardSolverBase _forwardSolverBaseMock;
+        private ForwardSolverBase _forwardSolverBaseMockWithSetup;
         private IEnumerable<double> _doubleEnumerable;
 
         [OneTimeSetUp]
         public void One_time_setup()
         {
-            _forwardSolverBaseMock = new Mock<ForwardSolverBase>()
-            {
-                CallBase = true
-            };
-            _forwardSolverBaseMockWithSetup = new Mock<ForwardSolverBase>()
-            {
-                CallBase = true
-            };
-            _forwardSolverBaseMockWithSetup.Setup(x => x.ROfRhoAndTime(It.IsAny<OpticalProperties>(), It.IsAny<double>(), It.IsAny<double>())).Returns(0.6);
-            _doubleEnumerable = _forwardSolverBaseMockWithSetup.Object.ROfRhoAndTime(
+            _forwardSolverBaseMock = Substitute.ForPartsOf<ForwardSolverBase>();
+            _forwardSolverBaseMockWithSetup = Substitute.ForPartsOf<ForwardSolverBase>();
+            _forwardSolverBaseMockWithSetup.ROfRhoAndTime(Arg.Any<OpticalProperties>(), Arg.Any<double>(), Arg.Any<double>()).Returns(0.6);
+            _doubleEnumerable = _forwardSolverBaseMockWithSetup.ROfRhoAndTime(
                 new List<OpticalProperties>
                 {
                     new OpticalProperties(0.1, 1, 0.8, 1.4),
@@ -48,7 +42,7 @@ namespace Vts.Test.Extensions
         public void Test_LoopOverVariables_with_two_values()
         {
             var doubleList =
-                _forwardSolverBaseMock.Object.ROfRho(new List<OpticalProperties>
+                _forwardSolverBaseMock.ROfRho(new List<OpticalProperties>
                 {
                     new OpticalProperties(0.1, 1, 0.8, 1.4),
                     new OpticalProperties(0.01, 1, 0.8, 1.4)
@@ -70,7 +64,7 @@ namespace Vts.Test.Extensions
         public void Test_LoopOverVariables_with_three_values()
         {
             var doubleList =
-                _forwardSolverBaseMock.Object.ROfRhoAndTime(new List<OpticalProperties>
+                _forwardSolverBaseMock.ROfRhoAndTime(new List<OpticalProperties>
                 {
                     new OpticalProperties(0.1, 1, 0.8, 1.4),
                     new OpticalProperties(0.01, 1, 0.8, 1.4)

--- a/src/Vts.Test/Factories/ComputationFactoryTests.cs
+++ b/src/Vts.Test/Factories/ComputationFactoryTests.cs
@@ -1,4 +1,4 @@
-using Moq;
+using NSubstitute;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
@@ -19,104 +19,59 @@ namespace Vts.Test.Factories
         private double[] _realFluence;
         private double[] _firstAxis, _secondAxis;
         private Complex[] _complexFluence;
-        private Mock<TwoLayerSDAForwardSolver> _twoLayerSdaForwardSolverMock;
-        private Mock<MonteCarloForwardSolver> _monteCarloForwardSolverMock;
+        private TwoLayerSDAForwardSolver _twoLayerSdaForwardSolverMock;
+        private MonteCarloForwardSolver _monteCarloForwardSolverMock;
 
         [OneTimeSetUp]
         public void One_time_setup()
         {
-            _twoLayerSdaForwardSolverMock = new Mock<TwoLayerSDAForwardSolver>()
-            {
-                CallBase = true
-            };
-            _monteCarloForwardSolverMock = new Mock<MonteCarloForwardSolver>()
-            {
-                CallBase = true
-            };
+            _twoLayerSdaForwardSolverMock = Substitute.ForPartsOf<TwoLayerSDAForwardSolver>();
+            _monteCarloForwardSolverMock = Substitute.ForPartsOf<MonteCarloForwardSolver>();
             // Setup the mocks for forward solver methods
             // ROfRho
-            _monteCarloForwardSolverMock.Setup(x => x.ROfRho(It.IsAny<OpticalProperties>(), It.IsAny<double>()))
-                .Returns(0.1);
+            _monteCarloForwardSolverMock.ROfRho(Arg.Any<OpticalProperties>(), Arg.Any<double>()).Returns(0.1);
             _twoLayerSdaForwardSolverMock
-                .Setup(x => x.ROfRho(It.IsAny<IOpticalPropertyRegion[]>(), It.IsAny<double>())).Returns(0.2);
+                .ROfRho(Arg.Any<IOpticalPropertyRegion[]>(), Arg.Any<double>()).Returns(0.2);
             // ROFTheta
-            _monteCarloForwardSolverMock.Setup(x => x.ROfTheta(It.IsAny<OpticalProperties>(), It.IsAny<double>()))
-                .Returns(0.3);
+            _monteCarloForwardSolverMock.ROfTheta(Arg.Any<OpticalProperties>(), Arg.Any<double>()).Returns(0.3);
             // ROfFx
-            _monteCarloForwardSolverMock.Setup(x => x.ROfFx(It.IsAny<OpticalProperties>(), It.IsAny<double>()))
-                .Returns(0.4);
+            _monteCarloForwardSolverMock.ROfFx(Arg.Any<OpticalProperties>(), Arg.Any<double>()).Returns(0.4);
             _twoLayerSdaForwardSolverMock
-                .Setup(x => x.ROfFx(It.IsAny<IOpticalPropertyRegion[]>(), It.IsAny<double>())).Returns(0.5);
+                .ROfFx(Arg.Any<IOpticalPropertyRegion[]>(), Arg.Any<double>()).Returns(0.5);
             // ROfRhoAndTime
-            _monteCarloForwardSolverMock.Setup(x =>
-                x.ROfRhoAndTime(It.IsAny<OpticalProperties>(), It.IsAny<double>(), It.IsAny<double>())).Returns(0.6);
-            _twoLayerSdaForwardSolverMock.Setup(x =>
-                    x.ROfRhoAndTime(It.IsAny<IOpticalPropertyRegion[]>(), It.IsAny<double>(), It.IsAny<double>()))
-                .Returns(0.7);
+            _monteCarloForwardSolverMock.ROfRhoAndTime(Arg.Any<OpticalProperties>(), Arg.Any<double>(), Arg.Any<double>()).Returns(0.6);
+            _twoLayerSdaForwardSolverMock.ROfRhoAndTime(Arg.Any<IOpticalPropertyRegion[]>(), Arg.Any<double>(), Arg.Any<double>()).Returns(0.7);
             // ROfRhoAndFt
             _monteCarloForwardSolverMock
-                .Setup(x => x.ROfRhoAndFt(It.IsAny<OpticalProperties>(), It.IsAny<double>(), It.IsAny<double>()))
-                .Returns(new Complex(0.8, 0));
+                .ROfRhoAndFt(Arg.Any<OpticalProperties>(), Arg.Any<double>(), Arg.Any<double>()).Returns(new Complex(0.8, 0));
             _twoLayerSdaForwardSolverMock
-                .Setup(x => x.ROfRhoAndFt(It.IsAny<IOpticalPropertyRegion[]>(), It.IsAny<double>(), It.IsAny<double>()))
-                .Returns(new Complex(0.9, 0));
+                .ROfRhoAndFt(Arg.Any<IOpticalPropertyRegion[]>(), Arg.Any<double>(), Arg.Any<double>()).Returns(new Complex(0.9, 0));
             // ROfFxAndTime
-            _monteCarloForwardSolverMock.Setup(x =>
-                x.ROfFxAndTime(It.IsAny<OpticalProperties>(), It.IsAny<double>(), It.IsAny<double>())).Returns(1.0);
-            _twoLayerSdaForwardSolverMock.Setup(x =>
-                    x.ROfFxAndTime(It.IsAny<IOpticalPropertyRegion[]>(), It.IsAny<double>(), It.IsAny<double>()))
-                .Returns(1.1);
+            _monteCarloForwardSolverMock.ROfFxAndTime(Arg.Any<OpticalProperties>(), Arg.Any<double>(), Arg.Any<double>()).Returns(1.0);
+            _twoLayerSdaForwardSolverMock.ROfFxAndTime(Arg.Any<IOpticalPropertyRegion[]>(), Arg.Any<double>(), Arg.Any<double>()).Returns(1.1);
             // ROfFxAndFt
             _monteCarloForwardSolverMock
-                .Setup(x => x.ROfFxAndFt(It.IsAny<OpticalProperties>(), It.IsAny<double>(), It.IsAny<double>()))
-                .Returns(new Complex(1.2, 0));
+                .ROfFxAndFt(Arg.Any<OpticalProperties>(), Arg.Any<double>(), Arg.Any<double>()).Returns(new Complex(1.2, 0));
             _twoLayerSdaForwardSolverMock
-                .Setup(x => x.ROfFxAndFt(It.IsAny<IOpticalPropertyRegion[]>(), It.IsAny<double>(), It.IsAny<double>()))
-                .Returns(new Complex(1.3, 0));
+                .ROfFxAndFt(Arg.Any<IOpticalPropertyRegion[]>(), Arg.Any<double>(), Arg.Any<double>()).Returns(new Complex(1.3, 0));
 
             // FluenceOfRhoAndZ
-            _monteCarloForwardSolverMock
-                .Setup(x => x.FluenceOfRhoAndZ(It.IsAny<IEnumerable<OpticalProperties>>(),
-                    It.IsAny<IEnumerable<double>>(), It.IsAny<IEnumerable<double>>()))
-                .Returns(new List<double> { 0.1, 0.2 });
+            _monteCarloForwardSolverMock.FluenceOfRhoAndZ(Arg.Any<IEnumerable<OpticalProperties>>(), Arg.Any<IEnumerable<double>>(), Arg.Any<IEnumerable<double>>()).Returns(new List<double> { 0.1, 0.2 });
             _twoLayerSdaForwardSolverMock
-                .Setup(x => x.FluenceOfRhoAndZ(It.IsAny<IEnumerable<IOpticalPropertyRegion[]>>(),
-                    It.IsAny<IEnumerable<double>>(), It.IsAny<IEnumerable<double>>()))
-                .Returns(new List<double> { 0.3, 0.4 });
+                .FluenceOfRhoAndZ(Arg.Any<IEnumerable<IOpticalPropertyRegion[]>>(), Arg.Any<IEnumerable<double>>(), Arg.Any<IEnumerable<double>>()).Returns(new List<double> { 0.3, 0.4 });
             // FluenceOfRhoAndZAndTime
             _monteCarloForwardSolverMock
-                .Setup(x => x.FluenceOfRhoAndZAndTime(It.IsAny<IEnumerable<OpticalProperties>>(),
-                    It.IsAny<IEnumerable<double>>(), It.IsAny<IEnumerable<double>>(), It.IsAny<IEnumerable<double>>()))
-                .Returns(new List<double> { 0.5, 0.6 });
-            _twoLayerSdaForwardSolverMock.Setup(x =>
-                    x.FluenceOfRhoAndZAndTime(It.IsAny<IEnumerable<IOpticalPropertyRegion[]>>(),
-                        It.IsAny<IEnumerable<double>>(), It.IsAny<IEnumerable<double>>(),
-                        It.IsAny<IEnumerable<double>>()))
-                .Returns(new List<double> { 0.7, 0.8 });
+                .FluenceOfRhoAndZAndTime(Arg.Any<IEnumerable<OpticalProperties>>(), Arg.Any<IEnumerable<double>>(), Arg.Any<IEnumerable<double>>(), Arg.Any<IEnumerable<double>>()).Returns(new List<double> { 0.5, 0.6 });
+            _twoLayerSdaForwardSolverMock.FluenceOfRhoAndZAndTime(Arg.Any<IEnumerable<IOpticalPropertyRegion[]>>(), Arg.Any<IEnumerable<double>>(), Arg.Any<IEnumerable<double>>(), Arg.Any<IEnumerable<double>>()).Returns(new List<double> { 0.7, 0.8 });
             // FluenceOfRhoAndZAndFt
-            _monteCarloForwardSolverMock
-                .Setup(x => x.FluenceOfRhoAndZAndFt(It.IsAny<IEnumerable<OpticalProperties>>(),
-                    It.IsAny<IEnumerable<double>>(), It.IsAny<IEnumerable<double>>(), It.IsAny<IEnumerable<double>>()))
-                .Returns(new List<Complex> { new Complex(0.9, 0), new Complex(1.0, 0) });
-            _twoLayerSdaForwardSolverMock
-                .Setup(x => x.FluenceOfRhoAndZAndFt(It.IsAny<IEnumerable<IOpticalPropertyRegion[]>>(),
-                    It.IsAny<IEnumerable<double>>(), It.IsAny<IEnumerable<double>>(), It.IsAny<IEnumerable<double>>()))
-                .Returns(new List<Complex> { new Complex(1.1, 0), new Complex(1.2, 0) });
+            _monteCarloForwardSolverMock.FluenceOfRhoAndZAndFt(Arg.Any<IEnumerable<OpticalProperties>>(), Arg.Any<IEnumerable<double>>(), Arg.Any<IEnumerable<double>>(), Arg.Any<IEnumerable<double>>()).Returns(new List<Complex> { new Complex(0.9, 0), new Complex(1.0, 0) });
+            _twoLayerSdaForwardSolverMock.FluenceOfRhoAndZAndFt(Arg.Any<IEnumerable<IOpticalPropertyRegion[]>>(), Arg.Any<IEnumerable<double>>(), Arg.Any<IEnumerable<double>>(), Arg.Any<IEnumerable<double>>()).Returns(new List<Complex> { new Complex(1.1, 0), new Complex(1.2, 0) });
             // FluenceOfFxAndZ
-            _monteCarloForwardSolverMock
-                .Setup(x => x.FluenceOfFxAndZ(It.IsAny<IEnumerable<OpticalProperties>>(),
-                    It.IsAny<IEnumerable<double>>(), It.IsAny<IEnumerable<double>>()))
-                .Returns(new List<double> { 1.3, 1.4 });
+            _monteCarloForwardSolverMock.FluenceOfFxAndZ(Arg.Any<IEnumerable<OpticalProperties>>(), Arg.Any<IEnumerable<double>>(), Arg.Any<IEnumerable<double>>()).Returns(new List<double> { 1.3, 1.4 });
             // FluenceOfFxAndZAndTime
-            _monteCarloForwardSolverMock
-                .Setup(x => x.FluenceOfFxAndZAndTime(It.IsAny<IEnumerable<OpticalProperties>>(),
-                    It.IsAny<IEnumerable<double>>(), It.IsAny<IEnumerable<double>>(), It.IsAny<IEnumerable<double>>()))
-                .Returns(new List<double> { 1.5, 1.6 });
+            _monteCarloForwardSolverMock.FluenceOfFxAndZAndTime(Arg.Any<IEnumerable<OpticalProperties>>(), Arg.Any<IEnumerable<double>>(), Arg.Any<IEnumerable<double>>(), Arg.Any<IEnumerable<double>>()).Returns(new List<double> { 1.5, 1.6 });
             // FluenceOfFxAndZAndFt
-            _monteCarloForwardSolverMock
-                .Setup(x => x.FluenceOfFxAndZAndFt(It.IsAny<IEnumerable<OpticalProperties>>(),
-                    It.IsAny<IEnumerable<double>>(), It.IsAny<IEnumerable<double>>(), It.IsAny<IEnumerable<double>>()))
-                .Returns(new List<Complex> { new Complex(1.7, 0), new Complex(1.8, 0) });
+            _monteCarloForwardSolverMock.FluenceOfFxAndZAndFt(Arg.Any<IEnumerable<OpticalProperties>>(), Arg.Any<IEnumerable<double>>(), Arg.Any<IEnumerable<double>>(), Arg.Any<IEnumerable<double>>()).Returns(new List<Complex> { new Complex(1.7, 0), new Complex(1.8, 0) });
         }
 
         [SetUp]
@@ -627,7 +582,7 @@ namespace Vts.Test.Factories
         {
             var independentValues = new[] { _firstAxis, _secondAxis };
             var fluence = ComputationFactory.ComputeFluence(
-                _twoLayerSdaForwardSolverMock.Object,
+                _twoLayerSdaForwardSolverMock,
                 FluenceSolutionDomainType.FluenceOfRhoAndZ,
                 new[] { IndependentVariableAxis.Rho, IndependentVariableAxis.Z },
                 independentValues,
@@ -647,7 +602,7 @@ namespace Vts.Test.Factories
         {
             var independentValues = new[] { _firstAxis, _secondAxis };
             var fluence = ComputationFactory.ComputeFluence(
-                _monteCarloForwardSolverMock.Object,
+                _monteCarloForwardSolverMock,
                 FluenceSolutionDomainType.FluenceOfFxAndZ,
                 new[] { IndependentVariableAxis.Fx, IndependentVariableAxis.Z },
                 independentValues,
@@ -661,7 +616,7 @@ namespace Vts.Test.Factories
         {
             var independentValues = new[] { _firstAxis, _secondAxis };
             var fluence = ComputationFactory.ComputeFluence(
-                _monteCarloForwardSolverMock.Object,
+                _monteCarloForwardSolverMock,
                 FluenceSolutionDomainType.FluenceOfRhoAndZAndTime,
                 new[] { IndependentVariableAxis.Rho, IndependentVariableAxis.Z, IndependentVariableAxis.Time },
                 independentValues,
@@ -675,7 +630,7 @@ namespace Vts.Test.Factories
         {
             var independentValues = new[] { _firstAxis, _secondAxis };
             var fluence = ComputationFactory.ComputeFluence(
-                _monteCarloForwardSolverMock.Object,
+                _monteCarloForwardSolverMock,
                 FluenceSolutionDomainType.FluenceOfRhoAndZAndTime,
                 new[] { IndependentVariableAxis.Time, IndependentVariableAxis.Rho, IndependentVariableAxis.Z },
                 independentValues,
@@ -689,7 +644,7 @@ namespace Vts.Test.Factories
         {
             var independentValues = new[] { _firstAxis, _secondAxis };
             var fluence = ComputationFactory.ComputeFluence(
-                _monteCarloForwardSolverMock.Object,
+                _monteCarloForwardSolverMock,
                 FluenceSolutionDomainType.FluenceOfFxAndZAndTime,
                 new[] { IndependentVariableAxis.Fx, IndependentVariableAxis.Z, IndependentVariableAxis.Time },
                 independentValues,
@@ -703,7 +658,7 @@ namespace Vts.Test.Factories
         {
             var independentValues = new[] { _firstAxis, _secondAxis };
             var fluence = ComputationFactory.ComputeFluence(
-                _monteCarloForwardSolverMock.Object,
+                _monteCarloForwardSolverMock,
                 FluenceSolutionDomainType.FluenceOfFxAndZAndTime,
                 new[] { IndependentVariableAxis.Time, IndependentVariableAxis.Fx, IndependentVariableAxis.Z },
                 independentValues,
@@ -721,7 +676,7 @@ namespace Vts.Test.Factories
                 try
                 {
                     ComputationFactory.ComputeFluence(
-                        _monteCarloForwardSolverMock.Object,
+                        _monteCarloForwardSolverMock,
                         (FluenceSolutionDomainType)Enum.GetValues(typeof(FluenceSolutionDomainType)).Length + 1,
                         new[] { IndependentVariableAxis.Time, IndependentVariableAxis.Fx, IndependentVariableAxis.Z },
                         independentValues,
@@ -744,7 +699,7 @@ namespace Vts.Test.Factories
                 try
                 {
                     ComputationFactory.ComputeFluence(
-                        _monteCarloForwardSolverMock.Object,
+                        _monteCarloForwardSolverMock,
                         FluenceSolutionDomainType.FluenceOfRhoAndZAndTime,
                         new[] { (IndependentVariableAxis)Enum.GetValues(typeof(IndependentVariableAxis)).Length + 1, IndependentVariableAxis.Fx, IndependentVariableAxis.Z },
                         independentValues,
@@ -767,7 +722,7 @@ namespace Vts.Test.Factories
                 try
                 {
                     ComputationFactory.ComputeFluence(
-                        _monteCarloForwardSolverMock.Object,
+                        _monteCarloForwardSolverMock,
                         FluenceSolutionDomainType.FluenceOfFxAndZAndTime,
                         new[] { (IndependentVariableAxis)Enum.GetValues(typeof(IndependentVariableAxis)).Length + 1, IndependentVariableAxis.Fx, IndependentVariableAxis.Z },
                         independentValues,
@@ -809,7 +764,7 @@ namespace Vts.Test.Factories
         {
             var independentValues = new[] { _firstAxis, _secondAxis };
             var fluence = ComputationFactory.ComputeFluenceComplex(
-                _twoLayerSdaForwardSolverMock.Object,
+                _twoLayerSdaForwardSolverMock,
                 FluenceSolutionDomainType.FluenceOfRhoAndZAndFt,
                 new[] { IndependentVariableAxis.Rho, IndependentVariableAxis.Z },
                 independentValues,
@@ -847,7 +802,7 @@ namespace Vts.Test.Factories
         {
             var independentValues = new[] { _firstAxis, _secondAxis };
             var fluence = ComputationFactory.ComputeFluenceComplex(
-                _monteCarloForwardSolverMock.Object,
+                _monteCarloForwardSolverMock,
                 FluenceSolutionDomainType.FluenceOfFxAndZAndFt,
                 new[] { IndependentVariableAxis.Fx, IndependentVariableAxis.Z },
                 independentValues,
@@ -866,7 +821,7 @@ namespace Vts.Test.Factories
         {
             var independentValues = new[] { _firstAxis, _secondAxis };
             var fluence = ComputationFactory.ComputeFluenceComplex(
-                _monteCarloForwardSolverMock.Object,
+                _monteCarloForwardSolverMock,
                 FluenceSolutionDomainType.FluenceOfFxAndZAndFt,
                 new[] { IndependentVariableAxis.Ft, IndependentVariableAxis.Z },
                 independentValues,
@@ -903,7 +858,7 @@ namespace Vts.Test.Factories
         {
             var independentValues = new[] { _firstAxis, _secondAxis };
             var fluence = ComputationFactory.ComputeFluenceComplex(
-                _twoLayerSdaForwardSolverMock.Object,
+                _twoLayerSdaForwardSolverMock,
                 FluenceSolutionDomainType.FluenceOfRhoAndZAndFt,
                 new[] { IndependentVariableAxis.Ft, IndependentVariableAxis.Z, IndependentVariableAxis.Rho },
                 independentValues,
@@ -1399,7 +1354,7 @@ namespace Vts.Test.Factories
         public void Validate_GetForwardReflectanceFunc_returns_data_for_ROfFx()
         {
             var reflectance = ComputationFactory.ComputeReflectance(
-                _monteCarloForwardSolverMock.Object,
+                _monteCarloForwardSolverMock,
                 SolutionDomainType.ROfFx,
                 ForwardAnalysisType.R,
                 new object[]
@@ -1415,7 +1370,7 @@ namespace Vts.Test.Factories
         public void Validate_GetForwardReflectanceFunc_returns_data_for_ROfRhoAndTime()
         {
             var reflectance = ComputationFactory.ComputeReflectance(
-                _monteCarloForwardSolverMock.Object,
+                _monteCarloForwardSolverMock,
                 SolutionDomainType.ROfRhoAndTime,
                 ForwardAnalysisType.R,
                 new object[]
@@ -1432,7 +1387,7 @@ namespace Vts.Test.Factories
         public void Validate_GetForwardReflectanceFunc_returns_data_for_ROfFxAndTime()
         {
             var reflectance = ComputationFactory.ComputeReflectance(
-                _monteCarloForwardSolverMock.Object,
+                _monteCarloForwardSolverMock,
                 SolutionDomainType.ROfFxAndTime,
                 ForwardAnalysisType.R,
                 new object[]
@@ -1449,7 +1404,7 @@ namespace Vts.Test.Factories
         public void Validate_GetForwardReflectanceFunc_returns_data_for_ROfRhoAndFt()
         {
             var reflectance = ComputationFactory.ComputeReflectance(
-                _monteCarloForwardSolverMock.Object,
+                _monteCarloForwardSolverMock,
                 SolutionDomainType.ROfRhoAndFt,
                 ForwardAnalysisType.R,
                 new object[]
@@ -1466,7 +1421,7 @@ namespace Vts.Test.Factories
         public void Validate_GetForwardReflectanceFunc_returns_data_for_ROfFxAndFt()
         {
             var reflectance = ComputationFactory.ComputeReflectance(
-                _monteCarloForwardSolverMock.Object,
+                _monteCarloForwardSolverMock,
                 SolutionDomainType.ROfFxAndFt,
                 ForwardAnalysisType.R,
                 new object[]
@@ -1497,7 +1452,7 @@ namespace Vts.Test.Factories
         public void Validate_GetForwardReflectanceFunc_2_layer_returns_data_for_ROfRho()
         {
             var reflectance = ComputationFactory.ComputeReflectance(
-                _twoLayerSdaForwardSolverMock.Object,
+                _twoLayerSdaForwardSolverMock,
                 SolutionDomainType.ROfRho,
                 ForwardAnalysisType.R,
                 new object[]
@@ -1518,7 +1473,7 @@ namespace Vts.Test.Factories
         public void Validate_GetForwardReflectanceFunc_2_layer_returns_data_for_ROfFx()
         {
             var reflectance = ComputationFactory.ComputeReflectance(
-                _twoLayerSdaForwardSolverMock.Object,
+                _twoLayerSdaForwardSolverMock,
                 SolutionDomainType.ROfFx,
                 ForwardAnalysisType.R,
                 new object[]
@@ -1539,7 +1494,7 @@ namespace Vts.Test.Factories
         public void Validate_GetForwardReflectanceFunc_2_layer_returns_data_for_ROfRhoAndTime()
         {
             var reflectance = ComputationFactory.ComputeReflectance(
-                _twoLayerSdaForwardSolverMock.Object,
+                _twoLayerSdaForwardSolverMock,
                 SolutionDomainType.ROfRhoAndTime,
                 ForwardAnalysisType.R,
                 new object[]
@@ -1564,7 +1519,7 @@ namespace Vts.Test.Factories
         public void Validate_GetForwardReflectanceFunc_2_layer_returns_data_for_ROfFxAndTime()
         {
             var reflectance = ComputationFactory.ComputeReflectance(
-                _twoLayerSdaForwardSolverMock.Object,
+                _twoLayerSdaForwardSolverMock,
                 SolutionDomainType.ROfFxAndTime,
                 ForwardAnalysisType.R,
                 new object[]
@@ -1589,7 +1544,7 @@ namespace Vts.Test.Factories
         public void Validate_GetForwardReflectanceFunc_2_layer_returns_data_for_ROfRhoAndFt()
         {
             var reflectance = ComputationFactory.ComputeReflectance(
-                _twoLayerSdaForwardSolverMock.Object,
+                _twoLayerSdaForwardSolverMock,
                 SolutionDomainType.ROfRhoAndFt,
                 ForwardAnalysisType.R,
                 new object[]
@@ -1611,7 +1566,7 @@ namespace Vts.Test.Factories
         public void Validate_GetForwardReflectanceFunc_2_layer_returns_data_for_ROfFxAndFt()
         {
             var reflectance = ComputationFactory.ComputeReflectance(
-                _twoLayerSdaForwardSolverMock.Object,
+                _twoLayerSdaForwardSolverMock,
                 SolutionDomainType.ROfFxAndFt,
                 ForwardAnalysisType.R,
                 new object[]

--- a/src/Vts.Test/Modeling/ForwardSolvers/ForwardSolverBaseTests.cs
+++ b/src/Vts.Test/Modeling/ForwardSolvers/ForwardSolverBaseTests.cs
@@ -1,4 +1,4 @@
-﻿using Moq;
+﻿using NSubstitute;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
@@ -13,8 +13,8 @@ namespace Vts.Test.Modeling.ForwardSolvers
     [TestFixture]
     public class ForwardSolverBaseTests
     {
-        private Mock<ForwardSolverBase> _forwardSolverBaseMock;
-        private Mock<ForwardSolverBase> _forwardSolverBaseMockWithSetup;
+        private ForwardSolverBase _forwardSolverBaseMock;
+        private ForwardSolverBase _forwardSolverBaseMockWithSetup;
         private TestForwardSolverBase _testForwardSolverBase;
         private OpticalProperties _opticalProperties;
         private IOpticalPropertyRegion[] _opticalPropertyRegions;
@@ -30,51 +30,45 @@ namespace Vts.Test.Modeling.ForwardSolvers
         [OneTimeSetUp]
         public void One_time_setup()
         {
-            _forwardSolverBaseMock = new Mock<ForwardSolverBase>()
-            {
-                CallBase = true
-            };
-            _forwardSolverBaseMockWithSetup = new Mock<ForwardSolverBase>()
-            {
-                CallBase = true
-            };
+            _forwardSolverBaseMock = Substitute.ForPartsOf<ForwardSolverBase>();
+            _forwardSolverBaseMockWithSetup = Substitute.ForPartsOf<ForwardSolverBase>();
             // Setup the mocks for the not implemented methods
             // ROfRho
-            _forwardSolverBaseMockWithSetup.Setup(x => x.ROfRho(It.IsAny<OpticalProperties>(), It.IsAny<double>())).Returns(0.1);
-            _forwardSolverBaseMockWithSetup.Setup(x => x.ROfRho(It.IsAny<IOpticalPropertyRegion[]>(), It.IsAny<double>())).Returns(0.2);
+            _forwardSolverBaseMockWithSetup.ROfRho(Arg.Any<OpticalProperties>(), Arg.Any<double>()).Returns(0.1);
+            _forwardSolverBaseMockWithSetup.ROfRho(Arg.Any<IOpticalPropertyRegion[]>(), Arg.Any<double>()).Returns(0.2);
             // ROFTheta
-            _forwardSolverBaseMockWithSetup.Setup(x => x.ROfTheta(It.IsAny<OpticalProperties>(), It.IsAny<double>())).Returns(0.3);
+            _forwardSolverBaseMockWithSetup.ROfTheta(Arg.Any<OpticalProperties>(), Arg.Any<double>()).Returns(0.3);
             // ROfFx
-            _forwardSolverBaseMockWithSetup.Setup(x => x.ROfFx(It.IsAny<OpticalProperties>(), It.IsAny<double>())).Returns(0.4);
-            _forwardSolverBaseMockWithSetup.Setup(x => x.ROfFx(It.IsAny<IOpticalPropertyRegion[]>(), It.IsAny<double>())).Returns(0.5);
+            _forwardSolverBaseMockWithSetup.ROfFx(Arg.Any<OpticalProperties>(), Arg.Any<double>()).Returns(0.4);
+            _forwardSolverBaseMockWithSetup.ROfFx(Arg.Any<IOpticalPropertyRegion[]>(), Arg.Any<double>()).Returns(0.5);
             // ROfRhoAndTime
-            _forwardSolverBaseMockWithSetup.Setup(x => x.ROfRhoAndTime(It.IsAny<OpticalProperties>(), It.IsAny<double>(), It.IsAny<double>())).Returns(0.6);
-            _forwardSolverBaseMockWithSetup.Setup(x => x.ROfRhoAndTime(It.IsAny<IOpticalPropertyRegion[]>(), It.IsAny<double>(), It.IsAny<double>())).Returns(0.7);
+            _forwardSolverBaseMockWithSetup.ROfRhoAndTime(Arg.Any<OpticalProperties>(), Arg.Any<double>(), Arg.Any<double>()).Returns(0.6);
+            _forwardSolverBaseMockWithSetup.ROfRhoAndTime(Arg.Any<IOpticalPropertyRegion[]>(), Arg.Any<double>(), Arg.Any<double>()).Returns(0.7);
             // ROfRhoAndFt
-            _forwardSolverBaseMockWithSetup.Setup(x => x.ROfRhoAndFt(It.IsAny<OpticalProperties>(), It.IsAny<double>(), It.IsAny<double>())).Returns(new Complex(0.8, 0));
-            _forwardSolverBaseMockWithSetup.Setup(x => x.ROfRhoAndFt(It.IsAny<IOpticalPropertyRegion[]>(), It.IsAny<double>(), It.IsAny<double>())).Returns(new Complex(0.9, 0));
+            _forwardSolverBaseMockWithSetup.ROfRhoAndFt(Arg.Any<OpticalProperties>(), Arg.Any<double>(), Arg.Any<double>()).Returns(new Complex(0.8, 0));
+            _forwardSolverBaseMockWithSetup.ROfRhoAndFt(Arg.Any<IOpticalPropertyRegion[]>(), Arg.Any<double>(), Arg.Any<double>()).Returns(new Complex(0.9, 0));
             // ROfFxAndTime
-            _forwardSolverBaseMockWithSetup.Setup(x => x.ROfFxAndTime(It.IsAny<OpticalProperties>(), It.IsAny<double>(), It.IsAny<double>())).Returns(1.0);
-            _forwardSolverBaseMockWithSetup.Setup(x => x.ROfFxAndTime(It.IsAny<IOpticalPropertyRegion[]>(), It.IsAny<double>(), It.IsAny<double>())).Returns(1.1);
+            _forwardSolverBaseMockWithSetup.ROfFxAndTime(Arg.Any<OpticalProperties>(), Arg.Any<double>(), Arg.Any<double>()).Returns(1.0);
+            _forwardSolverBaseMockWithSetup.ROfFxAndTime(Arg.Any<IOpticalPropertyRegion[]>(), Arg.Any<double>(), Arg.Any<double>()).Returns(1.1);
             // ROfFxAndFt
-            _forwardSolverBaseMockWithSetup.Setup(x => x.ROfFxAndFt(It.IsAny<OpticalProperties>(), It.IsAny<double>(), It.IsAny<double>())).Returns(new Complex(1.2, 0));
-            _forwardSolverBaseMockWithSetup.Setup(x => x.ROfFxAndFt(It.IsAny<IOpticalPropertyRegion[]>(), It.IsAny<double>(), It.IsAny<double>())).Returns(new Complex(1.3, 0));
+            _forwardSolverBaseMockWithSetup.ROfFxAndFt(Arg.Any<OpticalProperties>(), Arg.Any<double>(), Arg.Any<double>()).Returns(new Complex(1.2, 0));
+            _forwardSolverBaseMockWithSetup.ROfFxAndFt(Arg.Any<IOpticalPropertyRegion[]>(), Arg.Any<double>(), Arg.Any<double>()).Returns(new Complex(1.3, 0));
 
             // FluenceOfRhoAndZ
-            _forwardSolverBaseMockWithSetup.Setup(x => x.FluenceOfRhoAndZ(It.IsAny<IEnumerable<OpticalProperties>>(), It.IsAny<IEnumerable<double>>(), It.IsAny<IEnumerable<double>>())).Returns(new List<double> { 0.1, 0.2 });
-            _forwardSolverBaseMockWithSetup.Setup(x => x.FluenceOfRhoAndZ(It.IsAny< IEnumerable<IOpticalPropertyRegion[]>>(), It.IsAny< IEnumerable<double>>(), It.IsAny<IEnumerable<double>>())).Returns(new List<double> { 0.3, 0.4 });
+            _forwardSolverBaseMockWithSetup.FluenceOfRhoAndZ(Arg.Any<IEnumerable<OpticalProperties>>(), Arg.Any<IEnumerable<double>>(), Arg.Any<IEnumerable<double>>()).Returns(new List<double> { 0.1, 0.2 });
+            _forwardSolverBaseMockWithSetup.FluenceOfRhoAndZ(Arg.Any< IEnumerable<IOpticalPropertyRegion[]>>(), Arg.Any< IEnumerable<double>>(), Arg.Any<IEnumerable<double>>()).Returns(new List<double> { 0.3, 0.4 });
             // FluenceOfRhoAndZAndTime
-            _forwardSolverBaseMockWithSetup.Setup(x => x.FluenceOfRhoAndZAndTime(It.IsAny<IEnumerable<OpticalProperties>>(), It.IsAny<IEnumerable<double>>(), It.IsAny<IEnumerable<double>>(), It.IsAny<IEnumerable<double>>())).Returns(new List<double> { 0.5, 0.6 });
-            _forwardSolverBaseMockWithSetup.Setup(x => x.FluenceOfRhoAndZAndTime(It.IsAny<IEnumerable<IOpticalPropertyRegion[]>>(), It.IsAny<IEnumerable<double>>(), It.IsAny<IEnumerable<double>>(), It.IsAny<IEnumerable<double>>())).Returns(new List<double> { 0.7, 0.8 });
+            _forwardSolverBaseMockWithSetup.FluenceOfRhoAndZAndTime(Arg.Any<IEnumerable<OpticalProperties>>(), Arg.Any<IEnumerable<double>>(), Arg.Any<IEnumerable<double>>(), Arg.Any<IEnumerable<double>>()).Returns(new List<double> { 0.5, 0.6 });
+            _forwardSolverBaseMockWithSetup.FluenceOfRhoAndZAndTime(Arg.Any<IEnumerable<IOpticalPropertyRegion[]>>(), Arg.Any<IEnumerable<double>>(), Arg.Any<IEnumerable<double>>(), Arg.Any<IEnumerable<double>>()).Returns(new List<double> { 0.7, 0.8 });
             // FluenceOfRhoAndZAndFt
-            _forwardSolverBaseMockWithSetup.Setup(x => x.FluenceOfRhoAndZAndFt(It.IsAny<IEnumerable<OpticalProperties>>(), It.IsAny<IEnumerable<double>>(), It.IsAny<IEnumerable<double>>(), It.IsAny<IEnumerable<double>>())).Returns(new List<Complex> { new Complex(0.9, 0), new Complex(1.0, 0) });
-            _forwardSolverBaseMockWithSetup.Setup(x => x.FluenceOfRhoAndZAndFt(It.IsAny<IEnumerable<IOpticalPropertyRegion[]>>(), It.IsAny<IEnumerable<double>>(), It.IsAny<IEnumerable<double>>(), It.IsAny<IEnumerable<double>>())).Returns(new List<Complex> { new Complex(1.1, 0), new Complex(1.2, 0) });
+            _forwardSolverBaseMockWithSetup.FluenceOfRhoAndZAndFt(Arg.Any<IEnumerable<OpticalProperties>>(), Arg.Any<IEnumerable<double>>(), Arg.Any<IEnumerable<double>>(), Arg.Any<IEnumerable<double>>()).Returns(new List<Complex> { new Complex(0.9, 0), new Complex(1.0, 0) });
+            _forwardSolverBaseMockWithSetup.FluenceOfRhoAndZAndFt(Arg.Any<IEnumerable<IOpticalPropertyRegion[]>>(), Arg.Any<IEnumerable<double>>(), Arg.Any<IEnumerable<double>>(), Arg.Any<IEnumerable<double>>()).Returns(new List<Complex> { new Complex(1.1, 0), new Complex(1.2, 0) });
             // FluenceOfFxAndZ
-            _forwardSolverBaseMockWithSetup.Setup(x => x.FluenceOfFxAndZ(It.IsAny<IEnumerable<OpticalProperties>>(), It.IsAny<IEnumerable<double>>(), It.IsAny<IEnumerable<double>>())).Returns(new List<double> { 1.3, 1.4 });
+            _forwardSolverBaseMockWithSetup.FluenceOfFxAndZ(Arg.Any<IEnumerable<OpticalProperties>>(), Arg.Any<IEnumerable<double>>(), Arg.Any<IEnumerable<double>>()).Returns(new List<double> { 1.3, 1.4 });
             // FluenceOfFxAndZAndTime
-            _forwardSolverBaseMockWithSetup.Setup(x => x.FluenceOfFxAndZAndTime(It.IsAny<IEnumerable<OpticalProperties>>(), It.IsAny<IEnumerable<double>>(), It.IsAny<IEnumerable<double>>(), It.IsAny<IEnumerable<double>>())).Returns(new List<double> { 1.5, 1.6 });
+            _forwardSolverBaseMockWithSetup.FluenceOfFxAndZAndTime(Arg.Any<IEnumerable<OpticalProperties>>(), Arg.Any<IEnumerable<double>>(), Arg.Any<IEnumerable<double>>(), Arg.Any<IEnumerable<double>>()).Returns(new List<double> { 1.5, 1.6 });
             // FluenceOfFxAndZAndFt
-            _forwardSolverBaseMockWithSetup.Setup(x => x.FluenceOfFxAndZAndFt(It.IsAny<IEnumerable<OpticalProperties>>(), It.IsAny<IEnumerable<double>>(), It.IsAny<IEnumerable<double>>(), It.IsAny<IEnumerable<double>>())).Returns(new List<Complex> { new Complex(1.7, 0), new Complex(1.8, 0) });
+            _forwardSolverBaseMockWithSetup.FluenceOfFxAndZAndFt(Arg.Any<IEnumerable<OpticalProperties>>(), Arg.Any<IEnumerable<double>>(), Arg.Any<IEnumerable<double>>(), Arg.Any<IEnumerable<double>>()).Returns(new List<Complex> { new Complex(1.7, 0), new Complex(1.8, 0) });
 
             _testForwardSolverBase = new TestForwardSolverBase();
             // create the optical properties, arrays of optical property regions and IEnumberables
@@ -114,84 +108,84 @@ namespace Vts.Test.Modeling.ForwardSolvers
         [Test]
         public void Test_ROfRho_throws_not_implemented_exception()
         {
-            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.Object.ROfRho(_opticalProperties, 0.5));
+            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.ROfRho(_opticalProperties, 0.5));
         }
 
         [Test]
         public void Test_ROfRho_with_an_array_of_optical_property_regions_throws_not_implemented_exception()
         {
-            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.Object.ROfRho(
+            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.ROfRho(
                 _opticalPropertyRegions.ToArray(), 0.5));
         }
 
         [Test]
         public void Test_ROfTheta_throws_not_implemented_exception()
         {
-            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.Object.ROfTheta(_opticalProperties, 0.6));
+            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.ROfTheta(_opticalProperties, 0.6));
         }
 
         [Test]
         public void Test_ROfRhoAndTime_throws_not_implemented_exception()
         {
-            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.Object.ROfRhoAndTime(_opticalProperties, 0.5, 1));
+            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.ROfRhoAndTime(_opticalProperties, 0.5, 1));
         }
 
         [Test]
         public void Test_ROfRhoAndTime_with_an_array_of_optical_property_regions_throws_not_implemented_exception()
         {
-            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.Object.ROfRhoAndTime(
+            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.ROfRhoAndTime(
                 _opticalPropertyRegions.ToArray(), 0.5, 1));
         }
 
         [Test]
         public void Test_ROfRhoAndFt_throws_not_implemented_exception()
         {
-            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.Object.ROfRhoAndFt(_opticalProperties, 0.5, 0.1));
+            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.ROfRhoAndFt(_opticalProperties, 0.5, 0.1));
         }
 
         [Test]
         public void Test_ROfRhoAndFt_with_an_array_of_optical_property_regions_throws_not_implemented_exception()
         {
-            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.Object.ROfRhoAndFt(
+            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.ROfRhoAndFt(
                 _opticalPropertyRegions.ToArray(), 0.5, 1));
         }
 
         [Test]
         public void Test_ROfFx_throws_not_implemented_exception()
         {
-            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.Object.ROfFx(_opticalProperties, 0.2));
+            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.ROfFx(_opticalProperties, 0.2));
         }
 
         [Test]
         public void Test_ROfFx_with_an_array_of_optical_property_regions_throws_not_implemented_exception()
         {
-            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.Object.ROfFx(
+            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.ROfFx(
                 _opticalPropertyRegions.ToArray(), 0.2));
         }
 
         [Test]
         public void Test_ROfFxAndTime_throws_not_implemented_exception()
         {
-            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.Object.ROfFxAndTime(_opticalProperties, 0.2, 1));
+            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.ROfFxAndTime(_opticalProperties, 0.2, 1));
         }
 
         [Test]
         public void Test_ROfFxAndTime_with_an_array_of_optical_property_regions_throws_not_implemented_exception()
         {
-            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.Object.ROfFxAndTime(
+            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.ROfFxAndTime(
                 _opticalPropertyRegions.ToArray(), 0.2, 1));
         }
 
         [Test]
         public void Test_ROfFxAndFt_throws_not_implemented_exception()
         {
-            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.Object.ROfFxAndFt(_opticalProperties, 0.2, 0.5));
+            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.ROfFxAndFt(_opticalProperties, 0.2, 0.5));
         }
 
         [Test]
         public void Test_ROfFxAndFt_with_an_array_of_optical_property_regions_throws_not_implemented_exception()
         {
-            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.Object.ROfFxAndFt(
+            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.ROfFxAndFt(
                 _opticalPropertyRegions.ToArray(), 0.2, 0.5));
         }
 
@@ -199,7 +193,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfRho_with_IEnumerable_of_optical_properties_and_rhos()
         {
             var doubleList =
-                _forwardSolverBaseMockWithSetup.Object.ROfRho(_opticalPropertiesEnumerable, _doubles);
+                _forwardSolverBaseMockWithSetup.ROfRho(_opticalPropertiesEnumerable, _doubles);
             Assert.IsInstanceOf<IEnumerable<double>>(doubleList);
         }
 
@@ -207,7 +201,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfRho_with_IEnumerable_of_arrays_of_optical_property_regions_and_rhos()
         {
             var doubleList =
-                _forwardSolverBaseMockWithSetup.Object.ROfRho(_opticalPropertyRegionsEnumerable, _doubles);
+                _forwardSolverBaseMockWithSetup.ROfRho(_opticalPropertyRegionsEnumerable, _doubles);
             Assert.IsInstanceOf<IEnumerable<double>>(doubleList);
         }
 
@@ -215,7 +209,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfTheta_with_IEnumerable_of_optical_properties_and_thetas()
         {
             var doubleList =
-                _forwardSolverBaseMockWithSetup.Object.ROfTheta(_opticalPropertiesEnumerable, _doubles);
+                _forwardSolverBaseMockWithSetup.ROfTheta(_opticalPropertiesEnumerable, _doubles);
             Assert.IsInstanceOf<IEnumerable<double>>(doubleList);
         }
 
@@ -223,7 +217,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfRhoAndTime_with_IEnumerable_of_optical_properties_and_rhos_and_times()
         {
             var doubleList =
-                _forwardSolverBaseMockWithSetup.Object.ROfRhoAndTime(_opticalPropertiesEnumerable, _doubles, _doubles);
+                _forwardSolverBaseMockWithSetup.ROfRhoAndTime(_opticalPropertiesEnumerable, _doubles, _doubles);
             Assert.IsInstanceOf<IEnumerable<double>>(doubleList);
         }
 
@@ -231,7 +225,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfRhoAndTime_with_IEnumerable_of_arrays_of_optical_property_regions_and_rhos_and_times()
         {
             var doubleList =
-                _forwardSolverBaseMockWithSetup.Object.ROfRhoAndTime(_opticalPropertyRegionsEnumerable, _doubles, _doubles);
+                _forwardSolverBaseMockWithSetup.ROfRhoAndTime(_opticalPropertyRegionsEnumerable, _doubles, _doubles);
             Assert.IsInstanceOf<IEnumerable<double>>(doubleList);
         }
 
@@ -239,7 +233,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfRhoAndFt_with_IEnumerable_of_optical_properties_and_rhos_and_fts()
         {
             var complexList =
-                _forwardSolverBaseMockWithSetup.Object.ROfRhoAndFt(_opticalPropertiesEnumerable, _doubles, _doubles);
+                _forwardSolverBaseMockWithSetup.ROfRhoAndFt(_opticalPropertiesEnumerable, _doubles, _doubles);
             Assert.IsInstanceOf<IEnumerable<Complex>>(complexList);
         }
 
@@ -247,7 +241,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfRhoAndFt_with_IEnumerable_of_arrays_of_optical_property_regions_and_rhos_and_fts()
         {
             var complexList =
-                _forwardSolverBaseMockWithSetup.Object.ROfRhoAndFt(_opticalPropertyRegionsEnumerable, _doubles, _doubles);
+                _forwardSolverBaseMockWithSetup.ROfRhoAndFt(_opticalPropertyRegionsEnumerable, _doubles, _doubles);
             Assert.IsInstanceOf<IEnumerable<Complex>>(complexList);
         }
 
@@ -255,7 +249,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfFx_with_IEnumerable_of_optical_properties_and_fxs()
         {
             var doubleList =
-                _forwardSolverBaseMock.Object.ROfFx(_opticalPropertiesEnumerable, _doubles);
+                _forwardSolverBaseMock.ROfFx(_opticalPropertiesEnumerable, _doubles);
             Assert.IsInstanceOf<IEnumerable<double>>(doubleList);
         }
 
@@ -263,7 +257,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfFx_with_IEnumerable_of_arrays_of_optical_property_regions_and_fxs()
         {
             var doubleList =
-                _forwardSolverBaseMock.Object.ROfFx(_opticalPropertyRegionsEnumerable, _doubles);
+                _forwardSolverBaseMock.ROfFx(_opticalPropertyRegionsEnumerable, _doubles);
             Assert.IsInstanceOf<IEnumerable<double>>(doubleList);
         }
 
@@ -271,7 +265,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfFxAndTime_with_IEnumerable_of_optical_properties_and_fxs_and_times()
         {
             var doubleList =
-                _forwardSolverBaseMock.Object.ROfFxAndTime(_opticalPropertiesEnumerable, _doubles, _doubles);
+                _forwardSolverBaseMock.ROfFxAndTime(_opticalPropertiesEnumerable, _doubles, _doubles);
             Assert.IsInstanceOf<IEnumerable<double>>(doubleList);
         }
 
@@ -279,7 +273,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfFxAndTime_with_IEnumerable_of_arrays_of_optical_property_regions_and_fxs_and_times()
         {
             var doubleList =
-                _forwardSolverBaseMock.Object.ROfFxAndTime(_opticalPropertyRegionsEnumerable, _doubles, _doubles);
+                _forwardSolverBaseMock.ROfFxAndTime(_opticalPropertyRegionsEnumerable, _doubles, _doubles);
             Assert.IsInstanceOf<IEnumerable<double>>(doubleList);
         }
 
@@ -287,7 +281,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfFxAndFt_with_IEnumerable_of_optical_properties_and_fxs_and_fts()
         {
             var complexList =
-                _forwardSolverBaseMockWithSetup.Object.ROfFxAndFt(_opticalPropertiesEnumerable, _doubles, _doubles);
+                _forwardSolverBaseMockWithSetup.ROfFxAndFt(_opticalPropertiesEnumerable, _doubles, _doubles);
             Assert.IsInstanceOf<IEnumerable<Complex>>(complexList);
         }
 
@@ -295,7 +289,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfFxAndFt_with_IEnumerable_of_arrays_of_optical_property_regions_and_fxs_and_fts()
         {
             var complexList =
-                _forwardSolverBaseMockWithSetup.Object.ROfFxAndFt(_opticalPropertyRegionsEnumerable, _doubles, _doubles);
+                _forwardSolverBaseMockWithSetup.ROfFxAndFt(_opticalPropertyRegionsEnumerable, _doubles, _doubles);
             Assert.IsInstanceOf<IEnumerable<Complex>>(complexList);
         }
 
@@ -303,7 +297,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfRho_reflectance_array_overloads()
         {
             var doubles =
-                _forwardSolverBaseMockWithSetup.Object.ROfRho(_opticalPropertiesEnumerable.ToArray(), _doubles.ToArray());
+                _forwardSolverBaseMockWithSetup.ROfRho(_opticalPropertiesEnumerable.ToArray(), _doubles.ToArray());
             Assert.AreEqual(6, doubles.Length);
             Assert.AreEqual(0.1, doubles[0]);
         }
@@ -312,7 +306,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfRho_optical_property_region_reflectance_array_overloads()
         {
             var doubles =
-                _forwardSolverBaseMockWithSetup.Object.ROfRho(_opticalPropertyRegionsEnumerable.ToArray(), _doubles.ToArray());
+                _forwardSolverBaseMockWithSetup.ROfRho(_opticalPropertyRegionsEnumerable.ToArray(), _doubles.ToArray());
             Assert.AreEqual(6, doubles.Length);
             Assert.AreEqual(0.2, doubles[0]);
         }
@@ -321,7 +315,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_Theta_reflectance_array_overloads()
         {
             var doubles =
-                _forwardSolverBaseMockWithSetup.Object.ROfTheta(_opticalPropertiesEnumerable.ToArray(), _doubles.ToArray());
+                _forwardSolverBaseMockWithSetup.ROfTheta(_opticalPropertiesEnumerable.ToArray(), _doubles.ToArray());
             Assert.AreEqual(6, doubles.Length);
             Assert.AreEqual(0.3, doubles[0]);
         }
@@ -330,7 +324,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfFx_reflectance_array_overloads()
         {
             var doubles =
-                _forwardSolverBaseMockWithSetup.Object.ROfFx(_opticalPropertiesEnumerable.ToArray(), _doubles.ToArray());
+                _forwardSolverBaseMockWithSetup.ROfFx(_opticalPropertiesEnumerable.ToArray(), _doubles.ToArray());
             Assert.AreEqual(6, doubles.Length);
             Assert.AreEqual(0.4, doubles[0]);
         }
@@ -339,7 +333,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfFx_optical_property_region_reflectance_array_overloads()
         {
             var doubles =
-                _forwardSolverBaseMockWithSetup.Object.ROfFx(_opticalPropertyRegionsEnumerable.ToArray(), _doubles.ToArray());
+                _forwardSolverBaseMockWithSetup.ROfFx(_opticalPropertyRegionsEnumerable.ToArray(), _doubles.ToArray());
             Assert.AreEqual(6, doubles.Length);
             Assert.AreEqual(0.5, doubles[0]);
         }
@@ -348,7 +342,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfRhoAndTime_reflectance_array_overloads()
         {
             var doubles =
-                _forwardSolverBaseMockWithSetup.Object.ROfRhoAndTime(_opticalPropertiesEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray());
+                _forwardSolverBaseMockWithSetup.ROfRhoAndTime(_opticalPropertiesEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray());
             Assert.AreEqual(18, doubles.Length);
             Assert.AreEqual(0.6, doubles[0]);
         }
@@ -357,7 +351,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfRhoAndTime_optical_property_region_reflectance_array_overloads()
         {
             var doubles =
-                _forwardSolverBaseMockWithSetup.Object.ROfRhoAndTime(_opticalPropertyRegionsEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray());
+                _forwardSolverBaseMockWithSetup.ROfRhoAndTime(_opticalPropertyRegionsEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray());
             Assert.AreEqual(18, doubles.Length);
             Assert.AreEqual(0.7, doubles[0]);
         }
@@ -366,7 +360,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfRhoAndFt_reflectance_array_overloads()
         {
             var complexes =
-                _forwardSolverBaseMockWithSetup.Object.ROfRhoAndFt(_opticalPropertiesEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray());
+                _forwardSolverBaseMockWithSetup.ROfRhoAndFt(_opticalPropertiesEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray());
             Assert.AreEqual(18, complexes.Length);
             Assert.AreEqual(0.8, complexes[0].Real, 0.001);
         }
@@ -375,7 +369,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfRhoAndFt_optical_property_region_reflectance_array_overloads()
         {
             var complexes =
-                _forwardSolverBaseMockWithSetup.Object.ROfRhoAndFt(_opticalPropertyRegionsEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray());
+                _forwardSolverBaseMockWithSetup.ROfRhoAndFt(_opticalPropertyRegionsEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray());
             Assert.AreEqual(18, complexes.Length);
             Assert.AreEqual(0.9, complexes[0].Real, 0.001);
         }
@@ -384,7 +378,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfFxAndTime_reflectance_array_overloads()
         {
             var doubles =
-                _forwardSolverBaseMockWithSetup.Object.ROfFxAndTime(_opticalPropertiesEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray());
+                _forwardSolverBaseMockWithSetup.ROfFxAndTime(_opticalPropertiesEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray());
             Assert.AreEqual(18, doubles.Length);
             Assert.AreEqual(1.0, doubles[0]);
         }
@@ -393,7 +387,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfFxAndTime_optical_property_region_reflectance_array_overloads()
         {
             var doubles =
-                _forwardSolverBaseMockWithSetup.Object.ROfFxAndTime(_opticalPropertyRegionsEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray());
+                _forwardSolverBaseMockWithSetup.ROfFxAndTime(_opticalPropertyRegionsEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray());
             Assert.AreEqual(18, doubles.Length);
             Assert.AreEqual(1.1, doubles[0]);
         }
@@ -402,7 +396,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfFxAndFt_reflectance_array_overloads()
         {
             var complexes =
-                _forwardSolverBaseMockWithSetup.Object.ROfFxAndFt(_opticalPropertiesEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray());
+                _forwardSolverBaseMockWithSetup.ROfFxAndFt(_opticalPropertiesEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray());
             Assert.AreEqual(18, complexes.Length);
             Assert.AreEqual(1.2, complexes[0].Real, 0.001);
         }
@@ -411,7 +405,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfFxAndFt_optical_property_region_reflectance_array_overloads()
         {
             var complexes =
-                _forwardSolverBaseMockWithSetup.Object.ROfFxAndFt(_opticalPropertyRegionsEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray());
+                _forwardSolverBaseMockWithSetup.ROfFxAndFt(_opticalPropertyRegionsEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray());
             Assert.AreEqual(18, complexes.Length);
             Assert.AreEqual(1.3, complexes[0].Real, 0.001);
         }
@@ -419,7 +413,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         [Test]
         public void Test_ROfRho_overload_optical_properties_and_array_of_rhos()
         {
-            var doubles = _forwardSolverBaseMockWithSetup.Object.ROfRho(_opticalProperties, _doubles.ToArray());
+            var doubles = _forwardSolverBaseMockWithSetup.ROfRho(_opticalProperties, _doubles.ToArray());
             Assert.AreEqual(3, doubles.Length);
             Assert.AreEqual(0.1, doubles[2]);
         }
@@ -427,7 +421,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         [Test]
         public void Test_ROfRho_overload_optical_property_region_array_and_array_of_rhos()
         {
-            var doubles = _forwardSolverBaseMockWithSetup.Object.ROfRho(_opticalPropertyRegions, _doubles.ToArray());
+            var doubles = _forwardSolverBaseMockWithSetup.ROfRho(_opticalPropertyRegions, _doubles.ToArray());
             Assert.AreEqual(3, doubles.Length);
             Assert.AreEqual(0.2, doubles[0]);
         }
@@ -435,7 +429,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         [Test]
         public void Test_ROfRho_overload_optical_property_array_and_one_rho()
         {
-            var doubles = _forwardSolverBaseMockWithSetup.Object.ROfRho(_opticalPropertiesEnumerable.ToArray(), 0.5);
+            var doubles = _forwardSolverBaseMockWithSetup.ROfRho(_opticalPropertiesEnumerable.ToArray(), 0.5);
             Assert.AreEqual(2, doubles.Length);
             Assert.AreEqual(0.1, doubles[0]);
         }
@@ -443,7 +437,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         [Test]
         public void Test_ROfRho_overload_array_of_optical_property_region_array_and_one_rho()
         {
-            var doubles = _forwardSolverBaseMockWithSetup.Object.ROfRho(_opticalPropertyRegionsEnumerable.ToArray(), 0.5);
+            var doubles = _forwardSolverBaseMockWithSetup.ROfRho(_opticalPropertyRegionsEnumerable.ToArray(), 0.5);
             Assert.AreEqual(2, doubles.Length);
             Assert.AreEqual(0.2, doubles[0]);
         }
@@ -452,7 +446,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         [Test]
         public void Test_ROfTheta_overload_optical_properties_and_array_of_rhos()
         {
-            var doubles = _forwardSolverBaseMockWithSetup.Object.ROfTheta(_opticalProperties, _doubles.ToArray());
+            var doubles = _forwardSolverBaseMockWithSetup.ROfTheta(_opticalProperties, _doubles.ToArray());
             Assert.AreEqual(3, doubles.Length);
             Assert.AreEqual(0.3, doubles[0]);
         }
@@ -460,7 +454,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         [Test]
         public void Test_ROfTheta_overload_optical_property_array_and_one_rho()
         {
-            var doubles = _forwardSolverBaseMockWithSetup.Object.ROfTheta(_opticalPropertiesEnumerable.ToArray(), 0.5);
+            var doubles = _forwardSolverBaseMockWithSetup.ROfTheta(_opticalPropertiesEnumerable.ToArray(), 0.5);
             Assert.AreEqual(2, doubles.Length);
             Assert.AreEqual(0.3, doubles[0]);
         }
@@ -468,7 +462,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         [Test]
         public void Test_ROfRhoAndTime_overload_optical_properties_and_double_arrays()
         {
-            var doubles = _forwardSolverBaseMockWithSetup.Object.ROfRhoAndTime(_opticalProperties, _doubles.ToArray(), _doubles.ToArray());
+            var doubles = _forwardSolverBaseMockWithSetup.ROfRhoAndTime(_opticalProperties, _doubles.ToArray(), _doubles.ToArray());
             Assert.AreEqual(9, doubles.Length);
             Assert.AreEqual(0.6, doubles[0]);
         }
@@ -476,7 +470,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         [Test]
         public void Test_ROfRhoAndTime_overload_optical_properties_array_one_rho_time_array()
         {
-            var doubles = _forwardSolverBaseMockWithSetup.Object.ROfRhoAndTime(_opticalPropertiesEnumerable.ToArray(), 0.5, _doubles.ToArray());
+            var doubles = _forwardSolverBaseMockWithSetup.ROfRhoAndTime(_opticalPropertiesEnumerable.ToArray(), 0.5, _doubles.ToArray());
             Assert.AreEqual(6, doubles.Length);
             Assert.AreEqual(0.6, doubles[0]);
         }
@@ -484,7 +478,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         [Test]
         public void Test_ROfRhoAndTime_overload_array_optical_property_region_array_one_rho_time_array()
         {
-            var doubles = _forwardSolverBaseMockWithSetup.Object.ROfRhoAndTime(_opticalPropertyRegionsEnumerable.ToArray(), 0.5, _doubles.ToArray());
+            var doubles = _forwardSolverBaseMockWithSetup.ROfRhoAndTime(_opticalPropertyRegionsEnumerable.ToArray(), 0.5, _doubles.ToArray());
             Assert.AreEqual(6, doubles.Length);
             Assert.AreEqual(0.7, doubles[0]);
         }
@@ -492,7 +486,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         [Test]
         public void Test_ROfRhoAndTime_overload_optical_properties_array_rho_array_one_time()
         {
-            var doubles = _forwardSolverBaseMockWithSetup.Object.ROfRhoAndTime(_opticalPropertiesEnumerable.ToArray(), _doubles.ToArray(), 0.1);
+            var doubles = _forwardSolverBaseMockWithSetup.ROfRhoAndTime(_opticalPropertiesEnumerable.ToArray(), _doubles.ToArray(), 0.1);
             Assert.AreEqual(6, doubles.Length);
             Assert.AreEqual(0.6, doubles[0]);
         }
@@ -500,7 +494,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         [Test]
         public void Test_ROfRhoAndTime_overload_array_optical_property_region_array_rho_array_one_time()
         {
-            var doubles = _forwardSolverBaseMockWithSetup.Object.ROfRhoAndTime(_opticalPropertyRegionsEnumerable.ToArray(), _doubles.ToArray(), 0.1);
+            var doubles = _forwardSolverBaseMockWithSetup.ROfRhoAndTime(_opticalPropertyRegionsEnumerable.ToArray(), _doubles.ToArray(), 0.1);
             Assert.AreEqual(6, doubles.Length);
             Assert.AreEqual(0.7, doubles[0]);
         }
@@ -508,7 +502,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         [Test]
         public void Test_ROfRhoAndTime_overload_optical_property_region_array_one_rho_time_array()
         {
-            var doubles = _forwardSolverBaseMockWithSetup.Object.ROfRhoAndTime(_opticalPropertyRegions, 0.5, _doubles.ToArray());
+            var doubles = _forwardSolverBaseMockWithSetup.ROfRhoAndTime(_opticalPropertyRegions, 0.5, _doubles.ToArray());
             Assert.AreEqual(3, doubles.Length);
             Assert.AreEqual(0.7, doubles[0]);
         }
@@ -516,7 +510,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         [Test]
         public void Test_ROfRhoAndTime_overload_optical_property_region_array_rho_array_one_time()
         {
-            var doubles = _forwardSolverBaseMockWithSetup.Object.ROfRhoAndTime(_opticalPropertyRegions, _doubles.ToArray(), 0.1);
+            var doubles = _forwardSolverBaseMockWithSetup.ROfRhoAndTime(_opticalPropertyRegions, _doubles.ToArray(), 0.1);
             Assert.AreEqual(3, doubles.Length);
             Assert.AreEqual(0.7, doubles[0]);
         }
@@ -524,7 +518,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         [Test]
         public void Test_ROfRhoAndTime_overload_optical_property_region_array_one_rho_one_time()
         {
-            var doubles = _forwardSolverBaseMockWithSetup.Object.ROfRhoAndTime(_opticalPropertyRegionsEnumerable.ToArray(), 0.5, 0.1);
+            var doubles = _forwardSolverBaseMockWithSetup.ROfRhoAndTime(_opticalPropertyRegionsEnumerable.ToArray(), 0.5, 0.1);
             Assert.AreEqual(2, doubles.Length);
             Assert.AreEqual(0.7, doubles[0]);
         }
@@ -532,7 +526,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         [Test]
         public void Test_ROfRhoAndTime_overload_optical_property_region_array_rho_array_time_array()
         {
-            var doubles = _forwardSolverBaseMockWithSetup.Object.ROfRhoAndTime(_opticalPropertyRegions, _doubles.ToArray(), _doubles.ToArray());
+            var doubles = _forwardSolverBaseMockWithSetup.ROfRhoAndTime(_opticalPropertyRegions, _doubles.ToArray(), _doubles.ToArray());
             Assert.AreEqual(9, doubles.Length);
             Assert.AreEqual(0.7, doubles[0]);
         }
@@ -540,7 +534,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         [Test]
         public void Test_ROfRhoAndTime_overload_optical_properties_one_rho_time_array()
         {
-            var doubles = _forwardSolverBaseMockWithSetup.Object.ROfRhoAndTime(_opticalProperties, 0.5, _doubles.ToArray());
+            var doubles = _forwardSolverBaseMockWithSetup.ROfRhoAndTime(_opticalProperties, 0.5, _doubles.ToArray());
             Assert.AreEqual(3, doubles.Length);
             Assert.AreEqual(0.6, doubles[0]);
         }
@@ -548,7 +542,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         [Test]
         public void Test_ROfRhoAndTime_overload_optical_properties_rho_array_one_time()
         {
-            var doubles = _forwardSolverBaseMockWithSetup.Object.ROfRhoAndTime(_opticalProperties, _doubles.ToArray(), 0.1);
+            var doubles = _forwardSolverBaseMockWithSetup.ROfRhoAndTime(_opticalProperties, _doubles.ToArray(), 0.1);
             Assert.AreEqual(3, doubles.Length);
             Assert.AreEqual(0.6, doubles[0]);
         }
@@ -556,7 +550,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         [Test]
         public void Test_ROfRhoAndTime_overload_optical_properties_array_one_rho_one_time()
         {
-            var doubles = _forwardSolverBaseMockWithSetup.Object.ROfRhoAndTime(_opticalPropertiesEnumerable.ToArray(), 0.5, 0.1);
+            var doubles = _forwardSolverBaseMockWithSetup.ROfRhoAndTime(_opticalPropertiesEnumerable.ToArray(), 0.5, 0.1);
             Assert.AreEqual(2, doubles.Length);
             Assert.AreEqual(0.6, doubles[0]);
         }
@@ -564,7 +558,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         [Test]
         public void Test_ROfFx_overload_optical_properties_fx_array()
         {
-            var doubles = _forwardSolverBaseMockWithSetup.Object.ROfFx(_opticalProperties, _doubles.ToArray());
+            var doubles = _forwardSolverBaseMockWithSetup.ROfFx(_opticalProperties, _doubles.ToArray());
             Assert.AreEqual(3, doubles.Length);
             Assert.AreEqual(0.4, doubles[0]);
         }
@@ -572,7 +566,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         [Test]
         public void Test_ROfFx_overload_optical_properties_region_array_fx_array()
         {
-            var doubles = _forwardSolverBaseMockWithSetup.Object.ROfFx(_opticalPropertyRegions.ToArray(), _doubles.ToArray());
+            var doubles = _forwardSolverBaseMockWithSetup.ROfFx(_opticalPropertyRegions.ToArray(), _doubles.ToArray());
             Assert.AreEqual(3, doubles.Length);
             Assert.AreEqual(0.5, doubles[0]);
         }
@@ -580,7 +574,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         [Test]
         public void Test_ROfFx_overload_optical_properties_array_one_fx()
         {
-            var doubles = _forwardSolverBaseMockWithSetup.Object.ROfFx(_opticalPropertiesEnumerable.ToArray(), 0.1);
+            var doubles = _forwardSolverBaseMockWithSetup.ROfFx(_opticalPropertiesEnumerable.ToArray(), 0.1);
             Assert.AreEqual(2, doubles.Length);
             Assert.AreEqual(0.4, doubles[0]);
         }
@@ -588,7 +582,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         [Test]
         public void Test_ROfFx_overload_array_of_optical_properties_region_array_one_fx()
         {
-            var doubles = _forwardSolverBaseMockWithSetup.Object.ROfFx(_opticalPropertyRegionsEnumerable.ToArray(), 0.1);
+            var doubles = _forwardSolverBaseMockWithSetup.ROfFx(_opticalPropertyRegionsEnumerable.ToArray(), 0.1);
             Assert.AreEqual(2, doubles.Length);
             Assert.AreEqual(0.5, doubles[0]);
         }
@@ -597,7 +591,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfFxAndTime_overloads_optical_properties_fx_array_time_array()
         {
             var doubles =
-                _forwardSolverBaseMockWithSetup.Object.ROfFxAndTime(_opticalProperties, _doubles.ToArray(),
+                _forwardSolverBaseMockWithSetup.ROfFxAndTime(_opticalProperties, _doubles.ToArray(),
                     _doubles.ToArray());
             Assert.AreEqual(9, doubles.Length);
             Assert.AreEqual(1.0, doubles[0]);
@@ -607,7 +601,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfFxAndTime_overloads_optical_properties_array_one_fx_time_array()
         {
             var doubles =
-                _forwardSolverBaseMockWithSetup.Object.ROfFxAndTime(_opticalPropertiesEnumerable.ToArray(), 0.1,
+                _forwardSolverBaseMockWithSetup.ROfFxAndTime(_opticalPropertiesEnumerable.ToArray(), 0.1,
                     _doubles.ToArray());
             Assert.AreEqual(6, doubles.Length);
             Assert.AreEqual(1.0, doubles[0]);
@@ -617,7 +611,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfFxAndTime_overloads_optical_properties_array_fx_array_one_time()
         {
             var doubles =
-                _forwardSolverBaseMockWithSetup.Object.ROfFxAndTime(_opticalPropertiesEnumerable.ToArray(),
+                _forwardSolverBaseMockWithSetup.ROfFxAndTime(_opticalPropertiesEnumerable.ToArray(),
                     _doubles.ToArray(), 0.5);
             Assert.AreEqual(6, doubles.Length);
             Assert.AreEqual(1.0, doubles[0]);
@@ -627,7 +621,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfFxAndTime_overloads_optical_properties_one_fx_time_array()
         {
             var doubles =
-                _forwardSolverBaseMockWithSetup.Object.ROfFxAndTime(_opticalProperties, 0.1,
+                _forwardSolverBaseMockWithSetup.ROfFxAndTime(_opticalProperties, 0.1,
                     _doubles.ToArray());
             Assert.AreEqual(3, doubles.Length);
             Assert.AreEqual(1.0, doubles[0]);
@@ -637,7 +631,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfFxAndTime_overloads_optical_properties_fx_array_one_time()
         {
             var doubles =
-                _forwardSolverBaseMockWithSetup.Object.ROfFxAndTime(_opticalProperties,
+                _forwardSolverBaseMockWithSetup.ROfFxAndTime(_opticalProperties,
                     _doubles.ToArray(), 0.5);
             Assert.AreEqual(3, doubles.Length);
             Assert.AreEqual(1.0, doubles[0]);
@@ -647,7 +641,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfFxAndTime_overloads_optical_properties_array_one_fx_one_time()
         {
             var doubles =
-                _forwardSolverBaseMockWithSetup.Object.ROfFxAndTime(_opticalPropertiesEnumerable.ToArray(),
+                _forwardSolverBaseMockWithSetup.ROfFxAndTime(_opticalPropertiesEnumerable.ToArray(),
                     0.1, 0.5);
             Assert.AreEqual(2, doubles.Length);
             Assert.AreEqual(1.0, doubles[0]);
@@ -657,7 +651,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfFxAndTime_overloads_optical_property_region_array_fx_array_time_array()
         {
             var doubles =
-                _forwardSolverBaseMockWithSetup.Object.ROfFxAndTime(_opticalPropertyRegions.ToArray(),
+                _forwardSolverBaseMockWithSetup.ROfFxAndTime(_opticalPropertyRegions.ToArray(),
                     _doubles.ToArray(), _doubles.ToArray());
             Assert.AreEqual(9, doubles.Length);
             Assert.AreEqual(1.1, doubles[0]);
@@ -667,7 +661,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfFxAndTime_overloads_array_optical_property_region_array__one_fx_time_array()
         {
             var doubles =
-                _forwardSolverBaseMockWithSetup.Object.ROfFxAndTime(_opticalPropertyRegionsEnumerable.ToArray(),
+                _forwardSolverBaseMockWithSetup.ROfFxAndTime(_opticalPropertyRegionsEnumerable.ToArray(),
                     0.1, _doubles.ToArray());
             Assert.AreEqual(6, doubles.Length);
             Assert.AreEqual(1.1, doubles[0]);
@@ -677,7 +671,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfFxAndTime_overloads_optical_property_region_array_one_fx_time_array()
         {
             var doubles =
-                _forwardSolverBaseMockWithSetup.Object.ROfFxAndTime(_opticalPropertyRegions.ToArray(),
+                _forwardSolverBaseMockWithSetup.ROfFxAndTime(_opticalPropertyRegions.ToArray(),
                     0.1, _doubles.ToArray());
             Assert.AreEqual(3, doubles.Length);
             Assert.AreEqual(1.1, doubles[0]);
@@ -687,7 +681,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfFxAndTime_overloads_optical_property_region_array_fx_array_one_time()
         {
             var doubles =
-                _forwardSolverBaseMockWithSetup.Object.ROfFxAndTime(_opticalPropertyRegions.ToArray(),
+                _forwardSolverBaseMockWithSetup.ROfFxAndTime(_opticalPropertyRegions.ToArray(),
                     _doubles.ToArray(), 0.5);
             Assert.AreEqual(3, doubles.Length);
             Assert.AreEqual(1.1, doubles[0]);
@@ -697,7 +691,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfRhoAndFt_overloads_optical_properties_rho_array_ft_array()
         {
             var complexes =
-                _forwardSolverBaseMockWithSetup.Object.ROfRhoAndFt(_opticalProperties,
+                _forwardSolverBaseMockWithSetup.ROfRhoAndFt(_opticalProperties,
                     _doubles.ToArray(), _doubles.ToArray());
             Assert.AreEqual(9, complexes.Length);
             Assert.AreEqual(0.8, complexes[0].Real);
@@ -707,7 +701,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfRhoAndFt_overloads_optical_properties_array_one_rho_ft_array()
         {
             var complexes =
-                _forwardSolverBaseMockWithSetup.Object.ROfRhoAndFt(_opticalPropertiesEnumerable.ToArray(),
+                _forwardSolverBaseMockWithSetup.ROfRhoAndFt(_opticalPropertiesEnumerable.ToArray(),
                     0.5, _doubles.ToArray());
             Assert.AreEqual(6, complexes.Length);
             Assert.AreEqual(0.8, complexes[0].Real);
@@ -717,7 +711,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfRhoAndFt_overloads_optical_properties_array_rho_array_one_ft()
         {
             var complexes =
-                _forwardSolverBaseMockWithSetup.Object.ROfRhoAndFt(_opticalPropertiesEnumerable.ToArray(),
+                _forwardSolverBaseMockWithSetup.ROfRhoAndFt(_opticalPropertiesEnumerable.ToArray(),
                     _doubles.ToArray(), 0.2);
             Assert.AreEqual(6, complexes.Length);
             Assert.AreEqual(0.8, complexes[0].Real);
@@ -727,7 +721,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfRhoAndFt_overloads_optical_properties_one_rho_ft_array()
         {
             var complexes =
-                _forwardSolverBaseMockWithSetup.Object.ROfRhoAndFt(_opticalProperties,
+                _forwardSolverBaseMockWithSetup.ROfRhoAndFt(_opticalProperties,
                     0.5, _doubles.ToArray());
             Assert.AreEqual(3, complexes.Length);
             Assert.AreEqual(0.8, complexes[0].Real);
@@ -737,7 +731,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfRhoAndFt_overloads_optical_properties_rho_array_one_ft()
         {
             var complexes =
-                _forwardSolverBaseMockWithSetup.Object.ROfRhoAndFt(_opticalProperties,
+                _forwardSolverBaseMockWithSetup.ROfRhoAndFt(_opticalProperties,
                     _doubles.ToArray(), 0.2);
             Assert.AreEqual(3, complexes.Length);
             Assert.AreEqual(0.8, complexes[0].Real);
@@ -747,7 +741,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfRhoAndFt_overloads_optical_properties_array_one_rho_one_ft()
         {
             var complexes =
-                _forwardSolverBaseMockWithSetup.Object.ROfRhoAndFt(_opticalPropertiesEnumerable.ToArray(),
+                _forwardSolverBaseMockWithSetup.ROfRhoAndFt(_opticalPropertiesEnumerable.ToArray(),
                     0.5, 0.2);
             Assert.AreEqual(2, complexes.Length);
             Assert.AreEqual(0.8, complexes[0].Real);
@@ -757,7 +751,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfRhoAndFt_overloads_optical_property_region_array_rho_array_ft_array()
         {
             var complexes =
-                _forwardSolverBaseMockWithSetup.Object.ROfRhoAndFt(_opticalPropertyRegions.ToArray(),
+                _forwardSolverBaseMockWithSetup.ROfRhoAndFt(_opticalPropertyRegions.ToArray(),
                     _doubles.ToArray(), _doubles.ToArray());
             Assert.AreEqual(9, complexes.Length);
             Assert.AreEqual(0.9, complexes[0].Real);
@@ -767,7 +761,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfRhoAndFt_overloads_optical_property_region_array_one_rho_ft_array()
         {
             var complexes =
-                _forwardSolverBaseMockWithSetup.Object.ROfRhoAndFt(_opticalPropertyRegions.ToArray(),
+                _forwardSolverBaseMockWithSetup.ROfRhoAndFt(_opticalPropertyRegions.ToArray(),
                     0.5, _doubles.ToArray());
             Assert.AreEqual(3, complexes.Length);
             Assert.AreEqual(0.9, complexes[0].Real);
@@ -777,7 +771,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfRhoAndFt_overloads_optical_property_region_array_rho_array_one_ft()
         {
             var complexes =
-                _forwardSolverBaseMockWithSetup.Object.ROfRhoAndFt(_opticalPropertyRegions.ToArray(),
+                _forwardSolverBaseMockWithSetup.ROfRhoAndFt(_opticalPropertyRegions.ToArray(),
                     _doubles.ToArray(), 0.2);
             Assert.AreEqual(3, complexes.Length);
             Assert.AreEqual(0.9, complexes[0].Real);
@@ -787,7 +781,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfRhoAndFt_overloads_array_optical_property_region_array_rho_array_one_ft()
         {
             var complexes =
-                _forwardSolverBaseMockWithSetup.Object.ROfRhoAndFt(_opticalPropertyRegionsEnumerable.ToArray(),
+                _forwardSolverBaseMockWithSetup.ROfRhoAndFt(_opticalPropertyRegionsEnumerable.ToArray(),
                     _doubles.ToArray(), 0.2);
             Assert.AreEqual(6, complexes.Length);
             Assert.AreEqual(0.9, complexes[0].Real);
@@ -797,7 +791,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfRhoAndFt_overloads_array_optical_property_region_array_one_rho_ft_array()
         {
             var complexes =
-                _forwardSolverBaseMockWithSetup.Object.ROfRhoAndFt(_opticalPropertyRegionsEnumerable.ToArray(),
+                _forwardSolverBaseMockWithSetup.ROfRhoAndFt(_opticalPropertyRegionsEnumerable.ToArray(),
                     0.5, _doubles.ToArray());
             Assert.AreEqual(6, complexes.Length);
             Assert.AreEqual(0.9, complexes[0].Real);
@@ -807,7 +801,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfFxAndFt_overloads_optical_properties_fx_array_ft_array()
         {
             var complexes =
-                _forwardSolverBaseMockWithSetup.Object.ROfFxAndFt(_opticalProperties,
+                _forwardSolverBaseMockWithSetup.ROfFxAndFt(_opticalProperties,
                     _doubles.ToArray(), _doubles.ToArray());
             Assert.AreEqual(9, complexes.Length);
             Assert.AreEqual(1.2, complexes[0].Real);
@@ -817,7 +811,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfFxAndFt_overloads_optical_properties_array_one_fx_ft_array()
         {
             var complexes =
-                _forwardSolverBaseMockWithSetup.Object.ROfFxAndFt(_opticalPropertiesEnumerable.ToArray(),
+                _forwardSolverBaseMockWithSetup.ROfFxAndFt(_opticalPropertiesEnumerable.ToArray(),
                     0.2, _doubles.ToArray());
             Assert.AreEqual(6, complexes.Length);
             Assert.AreEqual(1.2, complexes[0].Real);
@@ -827,7 +821,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfFxAndFt_overloads_optical_properties_array_fx_array_one_ft()
         {
             var complexes =
-                _forwardSolverBaseMockWithSetup.Object.ROfFxAndFt(_opticalPropertiesEnumerable.ToArray(),
+                _forwardSolverBaseMockWithSetup.ROfFxAndFt(_opticalPropertiesEnumerable.ToArray(),
                     _doubles.ToArray(), 0.1);
             Assert.AreEqual(6, complexes.Length);
             Assert.AreEqual(1.2, complexes[0].Real);
@@ -837,7 +831,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfFxAndFt_overloads_optical_properties_one_fx_ft_array()
         {
             var complexes =
-                _forwardSolverBaseMockWithSetup.Object.ROfFxAndFt(_opticalProperties,
+                _forwardSolverBaseMockWithSetup.ROfFxAndFt(_opticalProperties,
                     0.1, _doubles.ToArray());
             Assert.AreEqual(3, complexes.Length);
             Assert.AreEqual(1.2, complexes[0].Real);
@@ -847,7 +841,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfFxAndFt_overloads_optical_properties_fx_array_one_ft()
         {
             var complexes =
-                _forwardSolverBaseMockWithSetup.Object.ROfFxAndFt(_opticalProperties,
+                _forwardSolverBaseMockWithSetup.ROfFxAndFt(_opticalProperties,
                     _doubles.ToArray(), 0.2);
             Assert.AreEqual(3, complexes.Length);
             Assert.AreEqual(1.2, complexes[0].Real);
@@ -857,7 +851,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfFxAndFt_overloads_optical_properties_array_one_fx_one_ft()
         {
             var complexes =
-                _forwardSolverBaseMockWithSetup.Object.ROfFxAndFt(_opticalPropertiesEnumerable.ToArray(),
+                _forwardSolverBaseMockWithSetup.ROfFxAndFt(_opticalPropertiesEnumerable.ToArray(),
                     0.1, 0.2);
             Assert.AreEqual(2, complexes.Length);
             Assert.AreEqual(1.2, complexes[0].Real);
@@ -867,7 +861,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfFxAndFt_overloads_optical_property_region_array_fx_array_ft_array()
         {
             var complexes =
-                _forwardSolverBaseMockWithSetup.Object.ROfFxAndFt(_opticalPropertyRegions.ToArray(),
+                _forwardSolverBaseMockWithSetup.ROfFxAndFt(_opticalPropertyRegions.ToArray(),
                     _doubles.ToArray(), _doubles.ToArray());
             Assert.AreEqual(9, complexes.Length);
             Assert.AreEqual(1.3, complexes[0].Real);
@@ -877,7 +871,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfFxAndFt_overloads_optical_property_region_array_one_fx_ft_array()
         {
             var complexes =
-                _forwardSolverBaseMockWithSetup.Object.ROfFxAndFt(_opticalPropertyRegions.ToArray(),
+                _forwardSolverBaseMockWithSetup.ROfFxAndFt(_opticalPropertyRegions.ToArray(),
                     0.1, _doubles.ToArray());
             Assert.AreEqual(3, complexes.Length);
             Assert.AreEqual(1.3, complexes[0].Real);
@@ -887,7 +881,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfFxAndFt_overloads_optical_property_region_array_fx_array_one_ft()
         {
             var complexes =
-                _forwardSolverBaseMockWithSetup.Object.ROfFxAndFt(_opticalPropertyRegions.ToArray(),
+                _forwardSolverBaseMockWithSetup.ROfFxAndFt(_opticalPropertyRegions.ToArray(),
                     _doubles.ToArray(), 0.2);
             Assert.AreEqual(3, complexes.Length);
             Assert.AreEqual(1.3, complexes[0].Real);
@@ -897,7 +891,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_ROfFxAndFt_overloads_array_optical_property_region_array_fx_array_one_ft()
         {
             var complexes =
-                _forwardSolverBaseMockWithSetup.Object.ROfFxAndFt(_opticalPropertyRegionsEnumerable.ToArray(),
+                _forwardSolverBaseMockWithSetup.ROfFxAndFt(_opticalPropertyRegionsEnumerable.ToArray(),
                     _doubles.ToArray(), 0.2);
             Assert.AreEqual(6, complexes.Length);
             Assert.AreEqual(1.3, complexes[0].Real);
@@ -906,62 +900,62 @@ namespace Vts.Test.Modeling.ForwardSolvers
         [Test]
         public void Test_FluenceOfRhoAndZ_throws_not_implemented_exception()
         {
-            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.Object.FluenceOfRhoAndZ(_opticalPropertiesEnumerable, _doubles, _doubles));
+            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.FluenceOfRhoAndZ(_opticalPropertiesEnumerable, _doubles, _doubles));
         }
 
         [Test]
         public void Test_FluenceOfRhoAndZ_with_an_array_of_optical_property_regions_throws_not_implemented_exception()
         {
-            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.Object.FluenceOfRhoAndZ(_opticalPropertyRegionsEnumerable, _doubles, _doubles));
+            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.FluenceOfRhoAndZ(_opticalPropertyRegionsEnumerable, _doubles, _doubles));
         }
 
         [Test]
         public void Test_FluenceOfRhoAndZAndTime_throws_not_implemented_exception()
         {
-            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.Object.FluenceOfRhoAndZAndTime(_opticalPropertiesEnumerable, _doubles, _doubles, _doubles));
+            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.FluenceOfRhoAndZAndTime(_opticalPropertiesEnumerable, _doubles, _doubles, _doubles));
         }
 
         [Test]
         public void Test_FluenceOfRhoAndZAndTime_with_an_array_of_optical_property_regions_throws_not_implemented_exception()
         {
-            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.Object.FluenceOfRhoAndZAndTime(_opticalPropertyRegionsEnumerable, _doubles, _doubles, _doubles));
+            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.FluenceOfRhoAndZAndTime(_opticalPropertyRegionsEnumerable, _doubles, _doubles, _doubles));
         }
 
         [Test]
         public void Test_FluenceOfRhoAndZAndFt_throws_not_implemented_exception()
         {
-            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.Object.FluenceOfRhoAndZAndFt(_opticalPropertiesEnumerable, _doubles, _doubles, _doubles));
+            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.FluenceOfRhoAndZAndFt(_opticalPropertiesEnumerable, _doubles, _doubles, _doubles));
         }
 
         [Test]
         public void Test_FluenceOfRhoAndZAndFt_with_an_array_of_optical_property_regions_throws_not_implemented_exception()
         {
-            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.Object.FluenceOfRhoAndZAndFt(_opticalPropertyRegionsEnumerable, _doubles, _doubles, _doubles));
+            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.FluenceOfRhoAndZAndFt(_opticalPropertyRegionsEnumerable, _doubles, _doubles, _doubles));
         }
 
         [Test]
         public void Test_FluenceOfFxAndZ_throws_not_implemented_exception()
         {
-            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.Object.FluenceOfFxAndZ(_opticalPropertiesEnumerable, _doubles, _doubles));
+            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.FluenceOfFxAndZ(_opticalPropertiesEnumerable, _doubles, _doubles));
         }
 
         [Test]
         public void Test_FluenceOfFxAndZAndTime_throws_not_implemented_exception()
         {
-            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.Object.FluenceOfFxAndZAndTime(_opticalPropertiesEnumerable, _doubles, _doubles, _doubles));
+            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.FluenceOfFxAndZAndTime(_opticalPropertiesEnumerable, _doubles, _doubles, _doubles));
         }
 
         [Test]
         public void Test_FluenceOfFxAndZAndFt_throws_not_implemented_exception()
         {
-            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.Object.FluenceOfFxAndZAndFt(_opticalPropertiesEnumerable, _doubles, _doubles, _doubles));
+            Assert.Throws<NotImplementedException>(() => _forwardSolverBaseMock.FluenceOfFxAndZAndFt(_opticalPropertiesEnumerable, _doubles, _doubles, _doubles));
         }
 
         [Test]
         public void Test_FluenceOfRhoAndZ_fluence_array_overloads()
         {
             var doubles =
-                _forwardSolverBaseMockWithSetup.Object.FluenceOfRhoAndZ(_opticalPropertiesEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray());
+                _forwardSolverBaseMockWithSetup.FluenceOfRhoAndZ(_opticalPropertiesEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray());
             Assert.AreEqual(18, doubles.Length);
             Assert.AreEqual(0.1, doubles[0], 0.00001);
             Assert.AreEqual(0.2, doubles[1], 0.00001);
@@ -971,7 +965,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_FluenceOfRhoAndZ_optical_property_region_reflectance_array_overloads()
         {
             var doubles =
-                _forwardSolverBaseMockWithSetup.Object.FluenceOfRhoAndZ(_opticalPropertyRegionsEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray());
+                _forwardSolverBaseMockWithSetup.FluenceOfRhoAndZ(_opticalPropertyRegionsEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray());
             Assert.AreEqual(18, doubles.Length);
             Assert.AreEqual(0.3, doubles[0], 0.00001);
             Assert.AreEqual(0.4, doubles[1], 0.00001);
@@ -981,7 +975,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_FluenceOfRhoAndZAndTime_fluence_array_overloads()
         {
             var doubles =
-                _forwardSolverBaseMockWithSetup.Object.FluenceOfRhoAndZAndTime(_opticalPropertiesEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray(), _doubles.ToArray());
+                _forwardSolverBaseMockWithSetup.FluenceOfRhoAndZAndTime(_opticalPropertiesEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray(), _doubles.ToArray());
             Assert.AreEqual(54, doubles.Length);
             Assert.AreEqual(0.5, doubles[0], 0.00001);
             Assert.AreEqual(0.6, doubles[1], 0.00001);
@@ -991,7 +985,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_FluenceOfRhoAndZAndTime_optical_property_region_reflectance_array_overloads()
         {
             var doubles =
-                _forwardSolverBaseMockWithSetup.Object.FluenceOfRhoAndZAndTime(_opticalPropertyRegionsEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray(), _doubles.ToArray());
+                _forwardSolverBaseMockWithSetup.FluenceOfRhoAndZAndTime(_opticalPropertyRegionsEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray(), _doubles.ToArray());
             Assert.AreEqual(54, doubles.Length);
             Assert.AreEqual(0.7, doubles[0], 0.00001);
             Assert.AreEqual(0.8, doubles[1], 0.00001);
@@ -1001,7 +995,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_FluenceOfRhoAndZAndFt_fluence_array_overloads()
         {
             var complexes =
-                _forwardSolverBaseMockWithSetup.Object.FluenceOfRhoAndZAndFt(_opticalPropertiesEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray(), _doubles.ToArray());
+                _forwardSolverBaseMockWithSetup.FluenceOfRhoAndZAndFt(_opticalPropertiesEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray(), _doubles.ToArray());
             Assert.AreEqual(54, complexes.Length);
             Assert.AreEqual(0.9, complexes[0].Real, 0.00001);
             Assert.AreEqual(1.0, complexes[1].Real, 0.00001);
@@ -1011,7 +1005,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_FluenceOfRhoAndZAndFt_optical_property_region_reflectance_array_overloads()
         {
             var complexes =
-                _forwardSolverBaseMockWithSetup.Object.FluenceOfRhoAndZAndFt(_opticalPropertyRegionsEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray(), _doubles.ToArray());
+                _forwardSolverBaseMockWithSetup.FluenceOfRhoAndZAndFt(_opticalPropertyRegionsEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray(), _doubles.ToArray());
             Assert.AreEqual(54, complexes.Length);
             Assert.AreEqual(1.1, complexes[0].Real, 0.00001);
             Assert.AreEqual(1.2, complexes[1].Real, 0.00001);
@@ -1021,7 +1015,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_FluenceOfFxAndZ_fluence_array_overloads()
         {
             var doubles =
-                _forwardSolverBaseMockWithSetup.Object.FluenceOfFxAndZ(_opticalPropertiesEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray());
+                _forwardSolverBaseMockWithSetup.FluenceOfFxAndZ(_opticalPropertiesEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray());
             Assert.AreEqual(18, doubles.Length);
             Assert.AreEqual(1.3, doubles[0], 0.00001);
             Assert.AreEqual(1.4, doubles[1], 0.00001);
@@ -1031,7 +1025,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_FluenceOfFxAndZAndTime_fluence_array_overloads()
         {
             var doubles =
-                _forwardSolverBaseMockWithSetup.Object.FluenceOfFxAndZAndTime(_opticalPropertiesEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray(), _doubles.ToArray());
+                _forwardSolverBaseMockWithSetup.FluenceOfFxAndZAndTime(_opticalPropertiesEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray(), _doubles.ToArray());
             Assert.AreEqual(54, doubles.Length);
             Assert.AreEqual(1.5, doubles[0], 0.00001);
             Assert.AreEqual(1.6, doubles[1], 0.00001);
@@ -1041,7 +1035,7 @@ namespace Vts.Test.Modeling.ForwardSolvers
         public void Test_FluenceOfFxAndZAndFt_fluence_array_overloads()
         {
             var complexes =
-                _forwardSolverBaseMockWithSetup.Object.FluenceOfFxAndZAndFt(_opticalPropertiesEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray(), _doubles.ToArray());
+                _forwardSolverBaseMockWithSetup.FluenceOfFxAndZAndFt(_opticalPropertiesEnumerable.ToArray(), _doubles.ToArray(), _doubles.ToArray(), _doubles.ToArray());
             Assert.AreEqual(54, complexes.Length);
             Assert.AreEqual(1.7, complexes[0].Real, 0.00001);
             Assert.AreEqual(1.8, complexes[1].Real, 0.00001);

--- a/src/Vts.Test/MonteCarlo/Factories/DetectorControllerFactoryTests.cs
+++ b/src/Vts.Test/MonteCarlo/Factories/DetectorControllerFactoryTests.cs
@@ -1,12 +1,9 @@
-﻿using System;
+﻿using NUnit.Framework;
+using System;
 using System.Collections.Generic;
-using NUnit.Framework;
-using Vts.Common;
 using Vts.MonteCarlo;
-using Vts.MonteCarlo.Factories;
-using MathNet.Numerics.Random;
-using Moq;
 using Vts.MonteCarlo.Detectors;
+using Vts.MonteCarlo.Factories;
 
 namespace Vts.Test.MonteCarlo.Factories
 {

--- a/src/Vts.Test/MonteCarlo/Factories/DetectorFactoryTests.cs
+++ b/src/Vts.Test/MonteCarlo/Factories/DetectorFactoryTests.cs
@@ -175,7 +175,7 @@ namespace Vts.Test.MonteCarlo.Factories
             // the following does not check exception it is aimed at
             var detectorInputMock = Substitute.For<IDetectorInput>();
             var detectorInputMockType = detectorInputMock.GetType();
-            Assert.Throws<ArgumentException>(() => DetectorFactory.RegisterDetector(
+            Assert.Throws<NotImplementedException>(() => DetectorFactory.RegisterDetector(
                 detectorInputMockType, typeof(IDetector)));
         }
 

--- a/src/Vts.Test/MonteCarlo/Factories/DetectorFactoryTests.cs
+++ b/src/Vts.Test/MonteCarlo/Factories/DetectorFactoryTests.cs
@@ -1,5 +1,4 @@
 ﻿using MathNet.Numerics.Random;
-using Moq;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
@@ -7,6 +6,7 @@ using System.IO;
 using System.Linq;
 // using the following for user-defined ROfXDetector implementation
 using System.Runtime.Serialization;
+using NSubstitute;
 using Vts.Common;
 using Vts.IO;
 using Vts.MonteCarlo;
@@ -173,7 +173,7 @@ namespace Vts.Test.MonteCarlo.Factories
             Assert.Throws<ArgumentException>(() => DetectorFactory.RegisterDetector(
                 typeof(RDiffuseDetectorInput), detectorBadType));
             // the following does not check exception it is aimed at
-            var detectorInputMock = new Mock<IDetectorInput>();
+            var detectorInputMock = Substitute.For<IDetectorInput>();
             var detectorInputMockType = detectorInputMock.GetType();
             Assert.Throws<ArgumentException>(() => DetectorFactory.RegisterDetector(
                 detectorInputMockType, typeof(IDetector)));

--- a/src/Vts.Test/MonteCarlo/Factories/RandomNumberGeneratorTests.cs
+++ b/src/Vts.Test/MonteCarlo/Factories/RandomNumberGeneratorTests.cs
@@ -1,12 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using NUnit.Framework;
-using Vts.Common;
-using Vts.MonteCarlo;
+﻿using NUnit.Framework;
+using System;
 using Vts.MonteCarlo.Factories;
-using MathNet.Numerics.Random;
-using Moq;
-using Vts.MonteCarlo.Detectors;
 
 namespace Vts.Test.MonteCarlo.Factories
 {

--- a/src/Vts.Test/MonteCarlo/Factories/SourceFactoryTests.cs
+++ b/src/Vts.Test/MonteCarlo/Factories/SourceFactoryTests.cs
@@ -1,14 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using MathNet.Numerics.Random;
+using NSubstitute;
 using NUnit.Framework;
+using System;
 using Vts.Common;
 using Vts.MonteCarlo;
-using Vts.MonteCarlo.Sources;
 using Vts.MonteCarlo.Factories;
-using MathNet.Numerics.Random;
-using Moq;
-using Vts.IO;
+using Vts.MonteCarlo.Sources;
 
 namespace Vts.Test.MonteCarlo.Factories
 {
@@ -41,13 +38,10 @@ namespace Vts.Test.MonteCarlo.Factories
         [Test]
         public void Demonstrate_GetSource_returns_null_on_faulty_tissue_input()
         {
-            var sourceInputMock = new Mock<ISourceInput>();
-            sourceInputMock.Setup(x => x.CreateSource(
-                It.IsAny<Random>())).Returns((ISource) null);
+            var sourceInputMock = Substitute.For<ISourceInput>();
+            sourceInputMock.CreateSource(Arg.Any<Random>()).Returns((ISource) null);
 
-            Assert.IsNull(SourceFactory.GetSource(
-                sourceInputMock.Object,
-                new MersenneTwister(0)));
+            Assert.IsNull(SourceFactory.GetSource(sourceInputMock, new MersenneTwister(0)));
         }
     }
 }

--- a/src/Vts.Test/MonteCarlo/Factories/TissueFactoryTests.cs
+++ b/src/Vts.Test/MonteCarlo/Factories/TissueFactoryTests.cs
@@ -1,10 +1,9 @@
-﻿using System;
+﻿using NSubstitute;
 using NUnit.Framework;
-using NUnit.Framework.Internal;
+using System;
 using Vts.MonteCarlo;
-using Vts.MonteCarlo.Tissues;
 using Vts.MonteCarlo.Factories;
-using Moq;
+using Vts.MonteCarlo.Tissues;
 
 namespace Vts.Test.MonteCarlo.Factories
 {
@@ -38,15 +37,15 @@ namespace Vts.Test.MonteCarlo.Factories
         [Test]
         public void Demonstrate_GetTissue_returns_null_on_faulty_tissue_input()
         {
-            var tissueInputMock = new Mock<ITissueInput>();
-            tissueInputMock.Setup(x => x.CreateTissue(
-                It.IsAny<AbsorptionWeightingType>(),
-                It.IsAny<PhaseFunctionType>(),
-                It.IsAny<double>())).Returns((ITissue)null);
+            var tissueInputMock = Substitute.For<ITissueInput>();
+            tissueInputMock.CreateTissue(
+                Arg.Any<AbsorptionWeightingType>(),
+                Arg.Any<PhaseFunctionType>(),
+                Arg.Any<double>()).Returns((ITissue)null);
 
             Assert.Throws<ArgumentException>(() =>
                 TissueFactory.GetTissue(
-                    tissueInputMock.Object,
+                    tissueInputMock,
                     AbsorptionWeightingType.Analog,
                     PhaseFunctionType.Bidirectional,
                     0.0));

--- a/src/Vts.Test/MonteCarlo/Sources/VolumetricSources/VolumetricCuboidal/CustomVolumetricCuboidalSourceTests.cs
+++ b/src/Vts.Test/MonteCarlo/Sources/VolumetricSources/VolumetricCuboidal/CustomVolumetricCuboidalSourceTests.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using MathNet.Numerics.Random;
-using Moq;
+﻿using MathNet.Numerics.Random;
 using NUnit.Framework;
+using System;
 using Vts.Common;
 using Vts.MonteCarlo;
 using Vts.MonteCarlo.Interfaces;

--- a/src/Vts.Test/Range/RangeOfTTests.cs
+++ b/src/Vts.Test/Range/RangeOfTTests.cs
@@ -1,4 +1,4 @@
-﻿using Moq;
+﻿using NSubstitute;
 using NUnit.Framework;
 using Vts.Common;
 
@@ -10,11 +10,8 @@ namespace Vts.Test.Range
         [Test]
         public void Test_default_constructor()
         {
-            var rangeMock = new Mock<Range<int>>
-            {
-                CallBase = true
-            };
-            Assert.AreEqual("Start: 0, Stop: 0, Count: 1, Delta: 0", rangeMock.Object.ToString());
+            var rangeMock = Substitute.ForPartsOf<Range<int>>();
+            Assert.AreEqual("Start: 0, Stop: 0, Count: 1, Delta: 0", rangeMock.ToString());
         }
 
         [Test]

--- a/src/Vts.Test/Range/RangeOfTTests.cs
+++ b/src/Vts.Test/Range/RangeOfTTests.cs
@@ -1,4 +1,5 @@
-﻿using NSubstitute;
+﻿using System;
+using NSubstitute;
 using NUnit.Framework;
 using Vts.Common;
 
@@ -10,7 +11,7 @@ namespace Vts.Test.Range
         [Test]
         public void Test_default_constructor()
         {
-            var rangeMock = Substitute.ForPartsOf<Range<int>>();
+            var rangeMock = Substitute.ForPartsOf<TestRange>();
             Assert.AreEqual("Start: 0, Stop: 0, Count: 1, Delta: 0", rangeMock.ToString());
         }
 
@@ -28,6 +29,19 @@ namespace Vts.Test.Range
             Assert.AreEqual("Start: 0, Stop: 9, Count: 10, Delta: 1", range.ToString());
             range.Delta = 2;
             Assert.AreEqual("Start: 0, Stop: 9, Count: 10, Delta: 2", range.ToString());
+        }
+    }
+
+    public class TestRange : Range<int>
+    {
+        protected override Func<int, int> GetIncrement()
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override int GetDelta()
+        {
+            return 0;
         }
     }
 }

--- a/src/Vts.Test/Vts.Test.csproj
+++ b/src/Vts.Test/Vts.Test.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Using Visual Studio's "Replace in Files", I used the following replacements with and without regular expressions.

`Replace "It.IsAny" with "Arg.Any"`

`Replace It.Is" with "Arg.Is"`

Use regular expressions:
`Replace "new Mock(?<type>.+)(( |\r|\n)+)\{(( |\r|\n)*)CallBase = true(( |\r|\n)*)\};" with "Substitute.ForPartsOf${type};"`

`Replace "new Mock" with "Substitute.For"`

Use regular expressions:
`Replace "Mock<(?<type>.+)>" with "${type}"`

Use regular expressions:
`Replace "(?<start>.+)\.Setup\(x => x(?<middle>.+)\)(( |\r|\n)*)\.Returns(?<end>(( |\r|\n)*))" with "${start}${middle}.Returns${end}"`
`Replace "(?<start>.+)\.SetupGet\(x => x(?<middle>.+)\)(( |\r|\n)*)\.Returns(?<end>(( |\r|\n)*))" with "${start}${middle}.Returns${end}"`

Use regular expressions:
`Replace "(?<start>.+)\.Verify\(x => x(?<middle>((.|\r|\n)+))(( |\r|\n)*)\, Times.Once\)(?<end>.+)" with "${start}.Received(1)${middle}${end}"`
`Replace "(?<start>.+)\.Verify\(x => x(?<middle>((.|\r|\n)+))(( |\r|\n)*)\, Times.Exactly\((?<times>.+)\)\)(?<end>.+)" with "${start}.Received(${times})${middle}${end}"`
`Replace "(?<start>.+)\.Verify\(x => x(?<middle>((.|\r|\n)+))(( |\r|\n)*)\, Times.Never\)(?<end>.+)" with "${start}.DidNotReceive()${middle}${end}"`

Other useful regular expressions:
`Replace "\r\n *\." with "." - Removes line breaks`
 