### PR TITLE
Added check if Matlab installed before running powershell commands that rely on its installation.

### DIFF
--- a/BuildTestRelease.ps1
+++ b/BuildTestRelease.ps1
@@ -2,6 +2,10 @@ $mccl_version = "7.3.0"
 $matlab_version = "10.0.0"
 
 Invoke-Expression ".\BuildTestReleaseMCCL.ps1 $mccl_version"
-Invoke-Expression ".\BuildTestReleaseMATLAB.ps1 $matlab_version"
+# only run if matlab installed
+if (Get-Command "matlab" -ErrorAction SilentlyContinue) 
+{
+  Invoke-Expression ".\BuildTestReleaseMATLAB.ps1 $matlab_version"
+}
 
 Read-Host -Prompt "Press Enter to exit"

--- a/BuildTestReleaseMCCL.ps1
+++ b/BuildTestReleaseMCCL.ps1
@@ -102,8 +102,12 @@ New-Item $MCmatlabdir -ItemType "directory"
 $MCresults = "$vtslevel\publish\local\one_layer_all_detectors\*"
 Copy-Item -Path $MCresults -Destination $MCmatlabdir -Recurse -ErrorAction Ignore
 
-# run load_results_script (default datanames is set to one_layer_all_detectors) 
-matlab -wait -r "load_results_script; quit"
+# only run following commands if matlab installed
+if (Get-Command "matlab" -ErrorAction SilentlyContinue)
+{
+  # run load_results_script (default datanames is set to one_layer_all_detectors) 
+  matlab -wait -r "load_results_script; quit"
+}
 
 #cleanup one_layer_all_detectors folder
 Remove-Item  $MCmatlabdir -Recurse -ErrorAction Ignore


### PR DESCRIPTION
I added powershell commands in BuildTestRelease.ps1 and BuildTestReleaseMCCL.ps1 to check if Matlab is installed and if not to not run any commands that rely on its installation.