### PR TITLE
feature/139-address-deprecation-warning-when-building-vts-under-net-v6

### DIFF
--- a/src/Vts/IO/BinaryArraySerializer.cs
+++ b/src/Vts/IO/BinaryArraySerializer.cs
@@ -9,11 +9,6 @@ namespace Vts.IO
     public class BinaryArraySerializer
     {
         /// <summary>
-        /// array to be written or read
-        /// </summary>
-        [Obsolete("The Serialization reconfiguration made this property obsolete.")]
-        public Array DataArray { get; set; }
-        /// <summary>
         /// name of array
         /// </summary>
         public string Name { get; set; }
@@ -21,12 +16,6 @@ namespace Vts.IO
         /// file tag string
         /// </summary>
         public string FileTag { get; set; }
-        /// <summary>
-        /// dimensions of array
-        /// </summary>
-        [Obsolete("Property was never used by the code and will be removed.")]
-        public int[] Dimensions { get; set; }
-
         /// <summary>
         /// method to write data
         /// </summary>

--- a/src/Vts/MonteCarlo/Helpers/SourceDefaults.cs
+++ b/src/Vts/MonteCarlo/Helpers/SourceDefaults.cs
@@ -22,11 +22,6 @@ namespace Vts.MonteCarlo.Sources
         /// </summary>
         public static PolarAzimuthalAngles DefaultBeamRotationFromInwardNormal => new PolarAzimuthalAngles(0.0, 0.0);
         /// <summary>
-        /// Default beam rotation angle from inward normal (0.0, 0.0)
-        /// </summary>
-        [Obsolete("DefaultBeamRoationFromInwardNormal is deprecated, please use DefaultBeamRotationFromInwardNormal instead.")]
-        public static PolarAzimuthalAngles DefaultBeamRoationFromInwardNormal => new PolarAzimuthalAngles(0.0, 0.0);
-        /// <summary>
         /// Default full polar angle range (0.0, PI)
         /// </summary>
         public static DoubleRange DefaultFullPolarAngleRange => new DoubleRange(0, Math.PI);

--- a/src/Vts/Range/RangeOfT.cs
+++ b/src/Vts/Range/RangeOfT.cs
@@ -119,10 +119,10 @@ namespace Vts
         /// <returns>A string that represents the current range</returns>
         public override string ToString()
         {
-            return "Start: " + Start.ToString() + 
-                 ", Stop: " + Stop.ToString() + 
-                 ", Count: " + Count.ToString() + 
-                 ", Delta: " + Delta.ToString();
+            return "Start: " + Start + 
+                 ", Stop: " + Stop + 
+                 ", Count: " + Count + 
+                 ", Delta: " + Delta;
         }
 
         /// <summary>
@@ -141,8 +141,7 @@ namespace Vts
         /// Returns an IEnumerable of type T that enumerates the range
         /// </summary>
         /// <returns>An IEnumerable of type T that enumerates the range</returns>
-        [Obsolete("This method is deprecated. Use built-in IEnumerable implementation instead.")]
-        public IEnumerable<T> AsEnumerable()
+        private IEnumerable<T> AsEnumerable()
         {
             var increment = GetIncrement();
 


### PR DESCRIPTION
- Removed all the obsolete methods and properties
- Made AsEnumerable private so that it is only used by the GetEnumerator method

@dcuccia I'm not sure if this is what you had in mind for removing the obsolete method, I tried other ways of implementing GetEnumerator() but this appeared to be the most straight-forward. If you have another suggestion, let me know.