### PR TITLE
Feature/197 powerlawscatterer option to define lambda0

### DIFF
--- a/src/Vts/Modeling/Spectroscopy/PowerLawScatterer.cs
+++ b/src/Vts/Modeling/Spectroscopy/PowerLawScatterer.cs
@@ -4,9 +4,10 @@ namespace Vts.SpectralMapping
 {
     /// <summary>
     /// Returns scattering values based on Steve Jacques' Skin Optics Summary:
-    /// https://omlc.ogi.edu/news/jan98/skinoptics.html
+    /// https://omlc.org/news/jan98/skinoptics.html
     /// This returned reduced scattering follows the approximate formula:
-    /// mus' = A1*lamda(-b1) + A2*lambda(-b2)
+    /// mus' = A1*(lamda/lambda0)(-b1) + A2*(lambda/lambda0)(-b2)
+    /// with default value of lambda0=1000nm
     /// </summary>
     public class PowerLawScatterer : BindableObject, IScatterer
     {
@@ -14,6 +15,7 @@ namespace Vts.SpectralMapping
         private double _b;
         private double _c;
         private double _d;
+        private double _lambda0;
 
         /// <summary>
         /// Constructs a power law scatterer; i.e. mus' = a*lamda^-b + c*lambda^-d
@@ -28,6 +30,7 @@ namespace Vts.SpectralMapping
             B = b;
             C = c;
             D = d;
+            Lambda0 = 1000; // use OMLC default value
         }
 
         /// <summary>
@@ -38,6 +41,23 @@ namespace Vts.SpectralMapping
         public PowerLawScatterer(double a, double b)
             : this(a,b,0.0,0.0)
         {
+        }
+
+        /// <summary>
+        /// Constructs a power law scatterer; i.e. mus' = a*(lamda/lambda0)^-b + c*(lambda/lambda0)^-d
+        /// </summary>
+        /// <param name="a">The first prefactor</param>
+        /// <param name="b">The first exponent</param>
+        /// <param name="c">The second prefactor</param>
+        /// <param name="d">The second exponent</param>
+        /// <param name="lambda0">Wavelength normalization factor</param>
+        public PowerLawScatterer(double a, double b, double c, double d, double lambda0)
+        {
+            A = a;
+            B = b;
+            C = c;
+            D = d;
+            Lambda0 = lambda0;
         }
 
         /// <summary>
@@ -70,6 +90,7 @@ namespace Vts.SpectralMapping
         /// <param name="tissueType">Tissue type</param>
         public void SetTissueType(TissueType tissueType)
         {
+            Lambda0 = 1000;
             switch (tissueType)
             {
                 case TissueType.Skin:
@@ -173,6 +194,19 @@ namespace Vts.SpectralMapping
             {
                 _d = value;
                 OnPropertyChanged("D");
+            }
+        }
+
+        /// <summary>
+        /// The wavelength normalization factor
+        /// </summary>
+        public double Lambda0
+        {
+            get => _lambda0;
+            set
+            {
+                _lambda0 = value;
+                OnPropertyChanged("Lambda0");
             }
         }
 

--- a/src/Vts/Modeling/Spectroscopy/Tissue.cs
+++ b/src/Vts/Modeling/Spectroscopy/Tissue.cs
@@ -93,12 +93,7 @@ namespace Vts.SpectralMapping
         /// <returns>The absorption coefficient Mua</returns>
         public double GetMua(double wavelength)
         {
-            double mua = 0.0;
-            for (int i = 0; i < Absorbers.Count; i++)
-            {
-                mua += Absorbers[i].GetMua(wavelength);
-            }
-            return mua;
+            return Absorbers.Sum(t => t.GetMua(wavelength));
         }
 
         /// <summary>
@@ -109,6 +104,21 @@ namespace Vts.SpectralMapping
         public double GetMusp(double wavelength)
         {
             return Scatterer != null ? Scatterer.GetMusp(wavelength) : 0;
+        }
+
+        /// <summary>
+        /// Returns the reduced scattering coefficient for a given wavelength
+        /// </summary>
+        /// <param name="wavelength">Wavelength</param>
+        /// <param name="lambda0">Wavelength normalization factor</param>
+        /// <returns>The reduced scattering coefficient Mus'</returns>
+        public double GetMusp(double wavelength, double lambda0)
+        {
+            if (Scatterer != null)
+            {
+                return Scatterer is PowerLawScatterer scatterer ? scatterer.GetMusp(wavelength, lambda0) : Scatterer.GetMusp(wavelength);
+            }
+            return 0;
         }
 
         /// <summary>
@@ -139,7 +149,7 @@ namespace Vts.SpectralMapping
         public OpticalProperties GetOpticalProperties(double wavelength)
         {
             var mua = GetMua(wavelength);
-            var musp = GetMusp(wavelength);
+            var musp = GetMusp(wavelength, 1000);
             var g = GetG(wavelength);
             var n = N;
             return new OpticalProperties(mua, musp, g, n);
@@ -148,18 +158,50 @@ namespace Vts.SpectralMapping
         /// <summary>
         /// Returns the optical properties for a given wavelength
         /// </summary>
+        /// <param name="wavelength">Wavelength</param>
+        /// <param name="lambda0">Wavelength normalization factor</param>
+        /// <returns>The optical properties</returns>
+        public OpticalProperties GetOpticalProperties(double wavelength, double lambda0)
+        {
+            var mua = GetMua(wavelength);
+            var musp = GetMusp(wavelength, lambda0);
+            var g = GetG(wavelength);
+            var n = N;
+            return new OpticalProperties(mua, musp, g, n);
+        }
+
+        /// <summary>
+        /// Returns the optical properties for an array of wavelengths
+        /// </summary>
         /// <param name="wavelengths">Wavelength</param>
         /// <returns>The optical properties</returns>
         public OpticalProperties[] GetOpticalProperties(double[] wavelengths)
         {
             var opArray = new OpticalProperties[wavelengths.Length];
-            for (int i = 0; i < wavelengths.Length; i++)
+            for (var i = 0; i < wavelengths.Length; i++)
             {
                 opArray[i] = GetOpticalProperties(wavelengths[i]);
             }
             return opArray;
         }
+
+        /// <summary>
+        /// Returns the optical properties for an array of wavelengths
+        /// </summary>
+        /// <param name="wavelengths">Wavelength</param>
+        /// <param name="lambda0">Wavelength normalization factor</param>
+        /// <returns>The optical properties</returns>
+        public OpticalProperties[] GetOpticalProperties(double[] wavelengths, double lambda0)
+        {
+            var opArray = new OpticalProperties[wavelengths.Length];
+            for (var i = 0; i < wavelengths.Length; i++)
+            {
+                opArray[i] = GetOpticalProperties(wavelengths[i], lambda0);
+            }
+            return opArray;
+        }
     }
+
     /// <summary>
     /// tissue provider class
     /// </summary>


### PR DESCRIPTION
I made an attempt at solving this by adding Property to PowerLawScatterer and overload to constructor.  In Tissue I added overload to GetMusp with parameter lambda0 which checks if Scatterer is PowerLawScatterer and if so call the overload with parameter lambda0.  Also needed to add 2 overloads to GetOpticalProperties, one for single wavelength and one for array of wavelengths.

I have not added unit tests.  Will do this once the code looks okay.