### PR TITLE
Update build.yaml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Build and analyze
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Install dotnet-coverage
         run: |


### PR DESCRIPTION
The windows-latest label now targets Windows 2025 and could cause problems in the pipeline.